### PR TITLE
Toggle event calendar and board members to 2017

### DIFF
--- a/about/board2017.html
+++ b/about/board2017.html
@@ -5,7 +5,7 @@
 ?>
 
         <h2 class="azbr-color">
-          2016 AZBR Board Members
+          2017 AZBR Board Members
         </h2>
 
         <div class="row">

--- a/autocross/calendar.html
+++ b/autocross/calendar.html
@@ -3,7 +3,7 @@
 
   Display::open_page();
 
-  $calendar_year = 2016;
+  $calendar_year = 2017;
 
   $json_string = MindTheCones::getRequest( "events/calendar/".$calendar_year."/", array( 'public' => 1 ));
   $events = json_decode( $json_string, true );
@@ -117,7 +117,7 @@
                   <?php echo $schedule['site_meeting']; ?>
                 </div>
               </div>
-<?php    
+<?php
   }
 ?>
 
@@ -134,14 +134,14 @@
                   </tr>
                 </thead>
                 <tbody>
-<?php 
+<?php
   $found_next = false;
   foreach( $events as $event ) {
 
     // show the event schedule when registration is open
     // and after it is closed until the day after the event
     $past = $event[ 'date_ts' ] + 24*60*60 < time();
-    $show_schedule = 
+    $show_schedule =
       (($event[ 'status' ] == "open" ) || ($event[ 'status' ] == "closed")) && !$past;
 ?>
 
@@ -221,7 +221,7 @@
               <div class="alert alert-info">
                 <?php show_schedule($schedules['fall']); ?>
               </div>
-              <div class="alert alert-info">              
+              <div class="alert alert-info">
                 <?php show_run_work($run_work['fall']); ?>
               </div>
 


### PR DESCRIPTION
# Why are we doing this?

New year, new schedule, new page for board members (even though they all remain the same).

Closes #8 

## How can someone view these changes?

[Dev Site]

![screen shot 2017-01-04 at 5 45 35 pm](https://cloud.githubusercontent.com/assets/1305168/21663420/b0da0fe6-d2a5-11e6-8a9a-e9711ce76bfa.png)

![screen shot 2017-01-04 at 5 45 46 pm](https://cloud.githubusercontent.com/assets/1305168/21663421/b434bee8-d2a5-11e6-8263-7b7f84fd3e26.png)


[Dev Site]: http://dev.azbrscca.org

## What possible risks or adverse effects are there?

None.

## What are the follow-up tasks?

Add information for the Test and Tune on 2/25 and the Teen Driving School on 11/11

## Are there any known issues?

None.