### PR TITLE
Remove Street Tire catgeory references

### DIFF
--- a/autocross/supplimental.html
+++ b/autocross/supplimental.html
@@ -11,7 +11,7 @@
 
               <h5 class="alert alert-warning text-center">
                 The regulations below apply to all events held by the Arizona Border Region SCCA
-                in addition to the rules specified in the official SCCA Rule Book. 
+                in addition to the rules specified in the official SCCA Rule Book.
               </h5>
 
               <h4><strong>Waiver of Liability</strong></h4>
@@ -31,7 +31,7 @@
                 All drivers must report to the registration table during the morning registration time. Each driver (with the exception of junior karts) must present his or her valid driver's license upon registering and paying for their event entry. SCCA members must present a valid and current SCCA membership card.
               <p/>
               <p>
-                Non-SCCA members must complete a weekend membership form to be allowed to participate. 
+                Non-SCCA members must complete a weekend membership form to be allowed to participate.
               </p>
 
               <h4><strong>Tech Inspection</strong></h4>
@@ -70,9 +70,6 @@
                 <em>Open</em> - Heads up (non-indexed) scoring against entrants in the same class. Any SCCA class is allowed and results are grouped by class (Open A Street, Open B Street, etc.)
               </p>
               <p>
-                <em>Street Tire</em> - Indexed scoring with any street-tired car that would normally run in a race tire class. This currently includes Street-R (A-H), Street Prepared (A-F), Prepared (A-G), Street Modified (SM, SMF, SSM) and Modified (A-F). No Street and Street Touring (including Classic American Muscle) classed cars may run in the Street Tire category.
-              </p>
-              <p>
                 <em>Ladies</em> - Ladies only, indexed scoring with any SCCA class allowed
               </p>
               <p>
@@ -83,10 +80,10 @@
               <p>
                 All events are a work/run format.  All competitors must be available to work one run group for each group in which they run.  This includes Time Only runs.  The Worker Chief will provide work assignments at each event, prior to the start of each group.  Any competitor not reporting for work will have their runs disqualified, and no results will be posted.  Multiple absences will result in that competitor being banned from future events.
               </p>
-          
+
               <h4><strong>Scoring &amp; Points</strong></h4>
               <p>
-                Each cone knocked over or out of place is a 2-second penalty.  Each deviation from the course (e.g., missing a gate, skipping a slalom cone) will result in the run being scored as a Did Not Finish (DNF).  Results for the event and the current Series will be determined by competitor's PAX time in their respective class.  PAX, Novice, and Street categories are treated as a single class for this purpose, with each competitor's score based on the vehicle's appropriate PAX class.  Note: ST, STS, STR, STX, and STU are not eligible for the Street Category, as PAX scores for those classes already take into account the use of street tires (tires with a tread wear rating of 140+).
+                Each cone knocked over or out of place is a 2-second penalty.  Each deviation from the course (e.g., missing a gate, skipping a slalom cone) will result in the run being scored as a Did Not Finish (DNF).  Results for the event and the current Series will be determined by competitor's PAX time in their respective class.  PAX and Novice categories are treated as a single class for this purpose, with each competitor's score based on the vehicle's appropriate PAX class.
               </p>
 
               <h4><strong>Refunds</strong></h4>
@@ -94,7 +91,7 @@
                 Should you choose to leave an event once paid/registered on site our policy on refunds is to provide credit. Be sure to request a credit record from one of the event organizers before you leave. This applies to competition and time only charges. Once you have made a run during a competition run group or time only run group credit will not be given. Examples of when a credit will be granted are: you have an emergency which requires you to leave prior to starting a competition or time only run group; your car does not pass inspection; or your car has a technical problem and cannot make it to grid for the first run.
               </p>
               <p>
-                Credits are valid for one year from the date of the credit. Redemption of credit can be made at future events. It's your responsibility to keep track of your credit. 
+                Credits are valid for one year from the date of the credit. Redemption of credit can be made at future events. It's your responsibility to keep track of your credit.
               </p>
             </div> <!-- / well well-sm -->
           </div>


### PR DESCRIPTION
## Why are we doing this?

Per email vote this week, the Border Region has decided to eliminate the Street Tire category. This PR removes references to the category from the supplemental regulations.

## How can someone view these changes?

[Dev site](http://dev.azbrscca.org/autocross/supplimental.html)

## What possible risks or adverse effects are there?

None, these updates are all test.

## What are the follow-up tasks?

Push to the live site.

## Are there any known issues?

None.
