### PR TITLE
Remove helmet notice

### DIFF
--- a/common/Display.php
+++ b/common/Display.php
@@ -158,7 +158,7 @@
                   <a href="#" class="dropdown-toggle" data-toggle="dropdown">Rallycross &amp; Road Rally  <b class="caret"></b></a>
                   <ul class="dropdown-menu">
                     <li class="dropdown-header">Rallycross</li>
-                    <li><a href="http://www.arizonarallygroup.com/">AZ Rally Group</a></li>
+                    <li><a href="https://www.facebook.com/AzRallyGroup">AZ Rally Group</a></li>
                     <li><a href="http://www.azsolo.com/forums/index.php?showforum=22">Rallycross Forums</a></li>
                     <li><a href="http://www.scca.com/pages/rallycross-cars-and-rules">SCCA Rallycross Rules</a></li>
                     <li class="divider"></li>

--- a/index.html
+++ b/index.html
@@ -15,23 +15,6 @@
 
           <div class="col-md-7">
 
-            <h2 class="azbr-color"><em>2017 Helmet Requirements - Must Read!</em></h2>
-            <div class="well well-sm">
-              <p>
-                As of 2017, <strong>SA2000 and M2000 rated helmets are no longer certified for SCCA Solo events</strong>.
-                This means that drivers and passengers must have a helmet certified 2005 or later to participate in SCCA
-                solo events. Please review
-                the <a href="http://cdn.growassets.net/user_files/scca/downloads/000/018/378/2017_Solo_helmet_cert_decals.pdf?1477497419">Required Helmet Certification Decals</a>
-                quick reference sheet published by the SCCA. Check the decal on your helmet for one of the decals pictured below
-                and ensure that your helmet will be legal <em>before</em> you show up to an event!
-              </p>
-              <p>
-                <a href="http://cdn.growassets.net/user_files/scca/downloads/000/018/378/2017_Solo_helmet_cert_decals.pdf?1477497419" class="thumbnail">
-                  <img class="img-responsive" src="<?php echo baseHref; ?>images/2017helmets.png" />
-                </a>
-              </p>
-            </div>
-
             <h2 class="azbr-color"><em>Autocross</em></h2>
             <div class="well well-sm">
               <?php AutoxEvents::upcoming_block( $deviceType ); ?>

--- a/rallycross/RallyxEvents.php
+++ b/rallycross/RallyxEvents.php
@@ -6,12 +6,11 @@
         <div class="row">
           <div class="col-md-12">
             <p>
-              RallyX events in Tucson are hosted by the <a href="http://azrallygroup.com/">Arizona Rally Group</a>
+              RallyX events in Tucson are hosted by the <a href="https://www.facebook.com/AzRallyGroup">Arizona Rally Group</a>
               at <a href="">MC Motorsports Park</a>. For event details, please visit the AZRG website or
               Facebook page.
             </p>
             <p class="text-center">
-              <a class="btn btn-primary btn-md" href="http://azrallygroup.com/">AZ Rally Group</a>
               <a class="btn btn-primary btn-md" href="http://mcmotorsportspark.com/">
                 MC Motorsports Park
               </a>
@@ -53,5 +52,3 @@
 
   } // end Class
 ?>
-
-


### PR DESCRIPTION
## Why are we doing this?

Previously scheduled removal of the helmet notice added with #5. Also update the rally group URLs to point to Facebook since that seems more up to date than the web site previously listed

## How can someone view these changes?

Visit the [dev site](http://dev.azbrscca.org/)
![screen shot 2017-04-16 at 3 24 55 pm](https://cloud.githubusercontent.com/assets/1305168/25074041/ee905f44-22b8-11e7-8f89-baced56241d2.png)

## What possible risks or adverse effects are there?

None.

## What are the follow-up tasks?

Deploy to the live site.

## Are there any known issues?

None