### PR TITLE
Expire road rally events, removing them from the front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,24 +113,6 @@
             <div class="well well-sm">
               <?php RallyxEvents::upcoming_block( $deviceType ); ?>
             </div>
-
-
-            <div data-expires="2017-07-09">
-              <h2 class="azbr-color"><em>Road Rally</em></h2>
-              <div class="well well-sm">
-                <p class="text-center">
-                  March 4 &amp; 5, 2017 - Sands and Sins!<br/>
-                  <strong>March 4: Desert Sands National Course Rally</strong><br/>
-                  <strong>March 5: Desert Sins National Course Rally</strong><br/>
-                </p>
-                <p class="text-center">
-                  <a class="btn btn-md btn-primary" href="<?php echo baseHref; ?>roadrally">
-                    More Information <i class="fa fa-angle-double-right"></i>
-                  </a>
-                </p>
-              </div>
-            </div>
-
           </div>
 
         </div><!-- / row -->


### PR DESCRIPTION
## Why are we doing this?

The Road Rally events on the took place last month and thus, this PR removes them from the front page.

## How can someone view these changes?

View the [dev site](http://dev.azbrscca.org).

Before:
![screen shot 2017-04-16 at 3 34 43 pm](https://cloud.githubusercontent.com/assets/1305168/25074120/66dff33c-22ba-11e7-8db9-4575edfaeff4.png)

After:
![screen shot 2017-04-16 at 3 35 35 pm](https://cloud.githubusercontent.com/assets/1305168/25074121/66e054f8-22ba-11e7-95fa-13c8ec84e217.png)

## What possible risks or adverse effects are there?

None.

## What are the follow-up tasks?

Push to the live site.

## Are there any known issues?

None.
