### PR TITLE
Support for showing events from multiple organizations

### DIFF
--- a/autocross/AutoxEvents.php
+++ b/autocross/AutoxEvents.php
@@ -203,7 +203,6 @@
 <?php   } ?>
           </div>
         </div>
-
 <?php
       }
     } // end function upcoming_block

--- a/autocross/AutoxEvents.php
+++ b/autocross/AutoxEvents.php
@@ -1,9 +1,9 @@
 <?php
   class AutoxEvents {
 
-    public static function avail_results( $deviceType = "unknown" ) {
+    public static function avail_results( $deviceType, $orgId, $apiKey) {
 
-      $data = MindTheCones::getRequest( "results/list/available" );
+      $data = MindTheCones::getRequest( "results/list/available", $orgId, $apiKey );
       $avail_results = json_decode( $data, true );
 ?>
 
@@ -62,7 +62,7 @@
                     <select class="form-control" id="classes" name="classes[]" multiple="multiple" size="4">
                     </select>
                   </div>
-                  
+
                   <div class="form-group">
                     <label for="categories">Categories to Display:</label>
                     <select class="form-control" id="categories" name="categories[]" multiple="multiple" size="4">
@@ -91,9 +91,9 @@
 <?php
 }
 
-    public static function past_tabs() {
+    public static function past_tabs($orgId, $apiKey) {
 
-      $past_events = MindTheCones::getRequest( "events/past/", array( 'limit' => 4 ));
+      $past_events = MindTheCones::getRequest( "events/past/", $orgId, $apiKey, array( 'limit' => 4 ));
       $events = json_decode( $past_events, true );
 ?>
             <div class="row">
@@ -115,12 +115,12 @@
                     <div class="row">
                       <div class="col-md-8">
                         <h5>
-                          <?php echo date( "F j", $event[ 'date_ts' ] ); ?> 
+                          <?php echo date( "F j", $event[ 'date_ts' ] ); ?>
                           <?php if ( !empty( $event[ 'name' ] ) ) { echo $event[ 'name' ]; } ?>
                           Autocross at <?php echo $event[ 'site_name' ]; ?>
                         </h5>
                       </div>
-                    
+
                       <?php if ( $event[ 'results' ] ) { ?>
                       <div class="col-md-4 text-right">
                         <a class="btn btn-primary" href="<?php echo baseHref; ?>autocross/results.html">
@@ -143,7 +143,7 @@
                       </div>
                     </div>
                     <?php
-                      } // course map thumbnail 
+                      } // course map thumbnail
                     ?>
                   </div>
                 <?php } ?>
@@ -155,15 +155,13 @@
 <?php
     } // end function past_tabs
 
-    public static function upcoming_block( $deviceType = "unknown" ) {
-
+    public static function upcoming_block( $deviceType, $orgId, $apiKey ) {
       $args = array( 'public' => 1 );
-      $json = MindTheCones::getRequest( "events/upcoming/open/", $args );
+      $json = MindTheCones::getRequest( "events/upcoming/open/", $orgId, $apiKey, $args );
       $autox_events = json_decode( $json, true );
-
       if ( empty( $autox_events ) ) {
         $args[ 'limit' ] = 1;
-        $json = MindTheCones::getRequest( "events/upcoming/", $args );
+        $json = MindTheCones::getRequest( "events/upcoming/", $orgId, $apiKey, $args );
         $autox_events = json_decode( $json, true );
       }
 
@@ -181,19 +179,19 @@
 <?php   if ( $event[ 'status' ] == "will open" ) { ?>
            <h4 class="text-center">
               Online registration will open:
-              <?php echo date( "l, F j", $event[ 'registration_open_ts' ] ); ?> at 
+              <?php echo date( "l, F j", $event[ 'registration_open_ts' ] ); ?> at
               <?php echo date( "g:ia", $event[ 'registration_open_ts' ] ); ?>.
             </h4>
 
 <?php   } else if ( $event[ 'status' ] == "open" ) { ?>
-    
+
             <h4 class="text-success text-center">
               Online registration is open now!
               <a class="btn btn-success" href="<?php echo mtc_url; ?>register/<?php echo $event[ 'id' ]; ?>" target="_top">Register Now</a>
             </h4>
             <h5 class="text-center">
               Online registration closes
-              <?php echo date( "l, F j", $event[ 'registration_close_ts' ] ); ?> at 
+              <?php echo date( "l, F j", $event[ 'registration_close_ts' ] ); ?> at
               <?php echo date( "g:ia", $event[ 'registration_close_ts' ] ); ?>.
             </h5>
 
@@ -211,7 +209,7 @@
         <div class="row">
           <div class="col-md-12">
 
-            <?php 
+            <?php
               $images = Functions::listFiles( "autocross/carousel", "jpg" );
               if ( $deviceType != "phone" ) {
             ?>
@@ -243,5 +241,3 @@
 
   } // end Class
 ?>
-
-

--- a/autocross/AutoxEvents.php
+++ b/autocross/AutoxEvents.php
@@ -204,40 +204,8 @@
           </div>
         </div>
 
-<?php } ?>
-
-        <div class="row">
-          <div class="col-md-12">
-
-            <?php
-              $images = Functions::listFiles( "autocross/carousel", "jpg" );
-              if ( $deviceType != "phone" ) {
-            ?>
-            <div id="autox-carousel" class="carousel slide" data-ride="carousel">
-              <div class="carousel-inner">
-                <?php foreach( $images as $index => $image ) {  ?>
-                <div class="item<?php if ( $index == 0 ) { echo " active"; } ?>">
-                  <img alt="" src="<?php echo baseHref.$image; ?>" />
-                </div>
-                <?php } ?>
-              </div>
-            </div>
-
-            <?php
-              } else {
-                $random = rand(0, sizeof($images)-1);
-            ?>
-            <img class="img-responsive" src="<?php echo baseHref.$images[$random]; ?>" />
-            <?php } ?>
-
-            <p>
-              Please refer to the <a href="<?php echo baseHref; ?>/autocross/calendar.html">event calendar</a>
-              for event schedules and run/work order.
-            </p>
-          </div>
-        </div>
 <?php
+      }
     } // end function upcoming_block
-
   } // end Class
 ?>

--- a/autocross/calendar.html
+++ b/autocross/calendar.html
@@ -5,7 +5,7 @@
 
   $calendar_year = 2017;
 
-  $json_string = MindTheCones::getRequest( "events/calendar/".$calendar_year."/", array( 'public' => 1 ));
+  $json_string = MindTheCones::getRequest( "events/calendar/".$calendar_year."/", $mtcIds['AZBR'], $mtcKeys['AZBR'], array( 'public' => 1 ));
   $events = json_decode( $json_string, true );
 
   $schedules = array(

--- a/autocross/courses/index.html
+++ b/autocross/courses/index.html
@@ -3,7 +3,7 @@
 
   Display::open_page();
 
-  $data = MindTheCones::getRequest( "events/past/" );
+  $data = MindTheCones::getRequest( "events/past/", $mtcIds['AZBR'], $mtcKeys['AZBR'] );
   $json = json_decode( $data, true );
 ?>
 

--- a/autocross/results.html
+++ b/autocross/results.html
@@ -15,7 +15,7 @@
         <div class="row">
           <div class="col-md-3">
             <div class="well well-sm">
-            <?php AutoxEvents::avail_results( $deviceType ) ?>
+            <?php AutoxEvents::avail_results( $deviceType, $mtcIds['AZBR'], $mtcKeys['AZBR'] ); ?>
             </div>
           </div>
 

--- a/autocross/results/download.html
+++ b/autocross/results/download.html
@@ -1,8 +1,8 @@
 <?php
   require_once "../../common/Common.php";
-  
+
   define( "timeOnly", "Time Only" );
-  
+
   if ( !empty( $_POST ) ) {
     $args = Functions::cleanArray( $_POST );
 
@@ -15,7 +15,7 @@
 
 
   function get_trophies( $num_cars ) {
-  
+
     $trophies = 0;
 
     if ( $num_cars > 0 ) { $trophies++; }
@@ -38,13 +38,12 @@
 
   function event_results_spreadsheet( $eventId ) {
 
-
-    $data = MindTheCones::getRequest( "db/events/".$eventId."/" );
+    $data = MindTheCones::getRequest( "db/events/".$eventId."/", $mtcIds['AZBR], $mtcKeys['AZBR'] );
     $event = json_decode( $data, true );
 
-    $data = MindTheCones::getRequest( "results/event/".$eventId."/" );
+    $data = MindTheCones::getRequest( "results/event/".$eventId."/", $mtcIds['AZBR], $mtcKeys['AZBR'] );
     $jsonData = json_decode( $data, true );
-    
+
     $results = array(
     	"PAX" => array(),
     	"Open" => array(),
@@ -57,7 +56,7 @@
     foreach( $jsonData as $item ) {
       array_push( $results[ $item[ 'category' ] ], $item );
     }
-    
+
     usort( $results[ 'Open' ], 'sortByClass' );
 
     header("Content-type: application/vnd.ms-excel");
@@ -67,7 +66,7 @@
     $sort_in = "category";
 
 
-    $results_fields = array( 
+    $results_fields = array(
                              "class_rank" => "Rank",
                              "class" => "Class",
                              "name" => "Name",
@@ -151,7 +150,7 @@
                   <td><?php echo number_format( $result[ 'pax_time' ], 3 ); ?></td>
                   <td><?php if ( $category != "Time Only" ) { echo $result[ 'pax_rank' ]; } else { "&nbsp;"; } ?></td>
                   <td><?php echo round( $result[ 'points' ] ); ?></td>
-                  
+
                 </tr>
 <?php
 			}
@@ -164,10 +163,10 @@
 
   function series_results_spreadsheet( $seriesId ) {
 
-    $data = MindTheCones::getRequest("db/series/".$seriesId."/");
+    $data = MindTheCones::getRequest("db/series/".$seriesId."/", $mtcIds['AZBR], $mtcKeys['AZBR']);
     $series = json_decode( $data, true );
 
-    $data = MindTheCones::getRequest("results/series/".$seriesId."/" );
+    $data = MindTheCones::getRequest("results/series/".$seriesId."/", $mtcIds['AZBR], $mtcKeys['AZBR']);
     $results = json_decode( $data, true );
 
     header("Content-type: application/vnd.ms-excel");
@@ -191,7 +190,7 @@
     foreach( $results[ 'series_events' ] as $event ) {
 ?>
                   <td><?php echo date( "M d", strtotime( $event[ 'event_date' ] ) ); ?></td>
-<?php      
+<?php
     }
 ?>
                   <td>Points</td>
@@ -242,7 +241,7 @@
 									</td>
 <?php
 		  				}
-?>					
+?>
 
                   <td><?php echo round( $result[ 'points' ] ); ?></td>
                 </tr>
@@ -291,7 +290,7 @@
 									</td>
 <?php
 		  		}
-?>					
+?>
                   <td><?php echo round( $result[ 'points' ] ); ?></td>
                 </tr>
 <?php

--- a/common/Display.php
+++ b/common/Display.php
@@ -158,6 +158,7 @@
                   <a href="#" class="dropdown-toggle" data-toggle="dropdown">Rallycross &amp; Road Rally  <b class="caret"></b></a>
                   <ul class="dropdown-menu">
                     <li class="dropdown-header">Rallycross</li>
+                    <li><a href="<?php echo baseHref; ?>rallycross/calendar.html">Event Calendar</a></li>
                     <li><a href="https://www.facebook.com/AzRallyGroup">AZ Rally Group</a></li>
                     <li><a href="http://www.azsolo.com/forums/index.php?showforum=22">Rallycross Forums</a></li>
                     <li><a href="http://www.scca.com/pages/rallycross-cars-and-rules">SCCA Rallycross Rules</a></li>

--- a/common/Display.php
+++ b/common/Display.php
@@ -1,6 +1,5 @@
 <?php
   class Display {
-
     public static function close_page( $jsSources = array(), $jsonData = array() ) {
 ?>
       </div> <!-- /container -->
@@ -22,6 +21,36 @@
 
   </body>
 </html>
+<?php
+    }
+
+    public static function image_carousel( $relPath, $format = "jpg" ) {
+?>
+    <div class="row">
+      <div class="col-md-12">
+
+        <?php
+          $images = Functions::listFiles( $relPath, $format );
+          if ( $deviceType != "phone" ) {
+        ?>
+        <div id="autox-carousel" class="carousel slide" data-ride="carousel">
+          <div class="carousel-inner">
+            <?php foreach( $images as $index => $image ) {  ?>
+            <div class="item<?php if ( $index == 0 ) { echo " active"; } ?>">
+              <img alt="" src="<?php echo baseHref.$image; ?>" />
+            </div>
+            <?php } ?>
+          </div>
+        </div>
+
+        <?php
+          } else {
+            $random = rand(0, sizeof($images)-1);
+        ?>
+        <img class="img-responsive" src="<?php echo baseHref.$images[$random]; ?>" />
+        <?php } ?>
+      </div>
+    </div>
 <?php
     }
 

--- a/common/MindTheCones.php
+++ b/common/MindTheCones.php
@@ -2,18 +2,8 @@
   class MindTheCones {
 
     public static $apiUrl = "";
-    private static $apiKey = "";
     private static $apiVersion = "1.0";
-    private static $orgId = 0;
     private static $useServerTime = false;
-
-    public static function getApiKey() {
-      return self::$apiKey;
-    }
-
-    public static function setApiKey( $apiKey ) {
-      self::$apiKey = $apiKey;
-    }
 
     public static function getApiUrl() {
       return self::$apiUrl;
@@ -27,14 +17,6 @@
       return self::$apiVersion;
     }
 
-    public static function getOrganizationId() {
-      return self::$orgId;
-    }
-
-    public static function setOrganizationId( $orgId ) {
-      self::$orgId = $orgId;
-    }
-
     public static function getUseServerTime() {
       return self::$useServerTime;
     }
@@ -43,8 +25,7 @@
       self::$useServerTime = $useServerTime;
     }
 
-    public static function getRequest( $uri, $get = array() ) {
-
+    public static function getRequest( $uri, $orgId, $apiKey, $get = array() ) {
       if ( strpos( $uri, '?' ) !== false ) {
         $uri = substr( $uri, 0, strpos( $uri, '?' ) );
       }
@@ -61,16 +42,16 @@
       }
 
       $requestToken = sha1(
-        MindTheCones::getApiKey() .
+        $apiKey .
         MindTheCones::getApiVersion() .
-        MindTheCones::getOrganizationId() .
+        $orgId .
         $requestTime
       );
 
       $params = array_merge(
         array(
           '__mtc_api_version' => MindTheCones::getApiVersion(),
-          '__mtc_organization_id' => MindTheCones::getOrganizationId(),
+          '__mtc_organization_id' => $orgId,
           '__mtc_request_time' => $requestTime,
           '__mtc_request_token' => $requestToken,
         ),
@@ -82,53 +63,9 @@
       if ( !empty( $queryString ) ) {
         $requestUrl .= "?".$queryString;
       }
-
       curl_setopt($ch, CURLOPT_URL, $requestUrl );
       curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
       curl_setopt($ch, CURLOPT_TIMEOUT, 15);
-      $data = curl_exec( $ch );
-      curl_close( $ch );
-
-      return $data;
-    }
-
-    public static function postRequest( $uri, $post ) {
-
-      $ch = curl_init();
-
-      $requestTime = time();
-      if ( self::getUseServerTime() ) {
-        $ch = curl_init();
-        curl_setopt( $ch, CURLOPT_URL, self::$apiUrl."/time" );
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 15);
-        $json = json_decode( curl_exec($ch), true );
-        $requestTime = intval( $json[ 'time' ] );
-      }
-
-      $requestToken = sha1(
-        MindTheCones::getApiKey() .
-        MindTheCones::getApiVersion() .
-        MindTheCones::getOrganizationId() .
-        $requestTime
-      );
-
-      $params = array_merge(
-        array(
-          '__mtc_api_version' => urlencode( MindTheCones::getApiVersion() ),
-          '__mtc_organization_id' => urlencode( MindTheCones::getOrganizationId() ),
-          '__mtc_request_time' => urlencode( $requestTime ),
-          '__mtc_request_token' => urlencode( $requestToken ),
-        ),
-        $post
-      );
-
-      curl_setopt($ch, CURLOPT_URL, self::$apiUrl.$uri );
-      curl_setopt($ch, CURLOPT_POST, 1);
-      curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query( $params ) );
-      curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-      curl_setopt($ch, CURLOPT_TIMEOUT, 15);
-
       $data = curl_exec( $ch );
       curl_close( $ch );
 

--- a/index.html
+++ b/index.html
@@ -37,6 +37,26 @@
             <h2 class="azbr-color"><em>Rallycross</em></h2>
             <div class="well well-sm">
               <?php RallyxEvents::upcoming_block( $deviceType, $mtcIds['AZRG'], $mtcKeys['AZRG'] ); ?>
+              <?php Display::image_carousel( "rallycross/carousel"); ?>
+              <div class="row">
+                <div class="col-md-12">
+                  <p>
+                    RallyX events in Tucson are hosted by the <a href="https://www.facebook.com/AzRallyGroup">Arizona Rally Group</a>
+                    at <a href="">MC Motorsports Park</a>. For event details, please visit the
+                    <a href="https://www.facebook.com/AzRallyGroup">Facebook page</a>. For a complete list of events, visit the
+                    <a href="<?php echo baseHref; ?>/rallycross/calendar.html">rallycross event calendar.</a>
+                    </p>
+                  </p>
+                  <p class="text-center">
+                    <a class="btn btn-primary btn-md" href="http://mcmotorsportspark.com/">
+                      MC Motorsports Park
+                    </a>
+                    <a class="btn btn-primary btn-md" href="https://www.facebook.com/AzRallyGroup" target="_top">
+                      <i class="fa fa-facebook"></i>
+                    </a>
+                  </p>
+                </div>
+              </div>
             </div>
 
             <h2 class="azbr-color"><em>Region #88</em></h2>

--- a/index.html
+++ b/index.html
@@ -30,6 +30,10 @@
             <h2 class="azbr-color"><em>Sierra Vista Autocross</em></h2>
             <div class="well well-sm">
               <?php AutoxEvents::upcoming_block( $deviceType, $mtcIds['SSCC'], $mtcKeys['SSCC'] ); ?>
+              <p>
+                Autocross events in Sierra Vista &amp; Bisbee are hosted by the <a href="http://sierrasportscars.net/">Sierra Sports Car Club</a>.
+                For event details and results, please visit <a href="http://sierrasportscars.net/">SierraSportsCars.net</a>.
+              </p>
             </div>
           </div>
 
@@ -40,10 +44,11 @@
               <?php Display::image_carousel( "rallycross/carousel"); ?>
               <div class="row">
                 <div class="col-md-12">
+                  <hr/>
                   <p>
-                    RallyX events in Tucson are hosted by the <a href="https://www.facebook.com/AzRallyGroup">Arizona Rally Group</a>
-                    at <a href="">MC Motorsports Park</a>. For event details, please visit the
-                    <a href="https://www.facebook.com/AzRallyGroup">Facebook page</a>. For a complete list of events, visit the
+                    Rallycross events in Tucson are hosted by the <a href="https://www.facebook.com/AzRallyGroup">Arizona Rally Group</a>.
+                    For event details and results, please visit the <a href="https://www.facebook.com/AzRallyGroup">AZ Rally Group Facebook page</a>.
+                    A complete list of events is also available through the
                     <a href="<?php echo baseHref; ?>/rallycross/calendar.html">rallycross event calendar.</a>
                     </p>
                   </p>

--- a/index.html
+++ b/index.html
@@ -14,13 +14,22 @@
         <div class="row">
 
           <div class="col-md-7">
-
-            <h2 class="azbr-color"><em>Autocross</em></h2>
+            <h2 class="azbr-color"><em>Tucson Autocross</em></h2>
             <div class="well well-sm">
               <?php AutoxEvents::upcoming_block( $deviceType, $mtcIds['AZBR'], $mtcKeys['AZBR'] ); ?>
+              <?php Display::image_carousel( "autocross/carousel"); ?>
+              <p>
+                Please refer to the <a href="<?php echo baseHref; ?>/autocross/calendar.html">event calendar</a>
+                for event schedules and run/work order.
+              </p>
             </div>
             <div class="well well-sm">
               <?php AutoxEvents::past_tabs( $mtcIds['AZBR'], $mtcKeys['AZBR'] ); ?>
+            </div>
+
+            <h2 class="azbr-color"><em>Sierra Vista Autocross</em></h2>
+            <div class="well well-sm">
+              <?php AutoxEvents::upcoming_block( $deviceType, $mtcIds['SSCC'], $mtcKeys['SSCC'] ); ?>
             </div>
           </div>
 

--- a/index.html
+++ b/index.html
@@ -25,6 +25,10 @@
           </div>
 
           <div class="col-md-5">
+            <h2 class="azbr-color"><em>Rallycross</em></h2>
+            <div class="well well-sm">
+              <?php RallyxEvents::upcoming_block( $deviceType ); ?>
+            </div>
 
             <h2 class="azbr-color"><em>Region #88</em></h2>
             <div class="well well-sm">
@@ -90,11 +94,6 @@
               <p>
                 Feel free to attend and enjoy free food and bench racing.
               </p>
-            </div>
-
-            <h2 class="azbr-color"><em>Rallycross</em></h2>
-            <div class="well well-sm">
-              <?php RallyxEvents::upcoming_block( $deviceType ); ?>
             </div>
           </div>
 

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
           <div class="col-md-5">
             <h2 class="azbr-color"><em>Rallycross</em></h2>
             <div class="well well-sm">
-              <?php RallyxEvents::upcoming_block( $deviceType ); ?>
+              <?php RallyxEvents::upcoming_block( $deviceType, $mtcIds['AZRG'], $mtcKeys['AZRG'] ); ?>
             </div>
 
             <h2 class="azbr-color"><em>Region #88</em></h2>

--- a/index.html
+++ b/index.html
@@ -17,10 +17,10 @@
 
             <h2 class="azbr-color"><em>Autocross</em></h2>
             <div class="well well-sm">
-              <?php AutoxEvents::upcoming_block( $deviceType ); ?>
+              <?php AutoxEvents::upcoming_block( $deviceType, $mtcIds['AZBR'], $mtcKeys['AZBR'] ); ?>
             </div>
             <div class="well well-sm">
-              <?php AutoxEvents::past_tabs(); ?>
+              <?php AutoxEvents::past_tabs( $mtcIds['AZBR'], $mtcKeys['AZBR'] ); ?>
             </div>
           </div>
 

--- a/mtc/index.html
+++ b/mtc/index.html
@@ -1,6 +1,6 @@
 <?php
   require_once "../common/Common.php";
-  
+
   $apiFlag = "mtc/";
   $method = strtoupper( $_SERVER[ 'REQUEST_METHOD' ] );
   $uri = substr( $_SERVER[ 'REQUEST_URI' ],
@@ -13,11 +13,7 @@
       if ( strpos( $uri, '?' ) !== false ) {
         $uri = substr( $uri, 0, strpos( $uri, '?' ) );
       }
-      echo MindTheCones::getRequest( $uri, $_GET );
-    break;
-
-    case 'POST':
-      echo MindTheCones::postRequest( $uri, $_POST );
+      echo MindTheCones::getRequest( $uri, $mtcIds['AZBR'], $mtcKeys['AZBR'], $_GET );
     break;
 
     default:

--- a/rallycross/RallyxEvents.php
+++ b/rallycross/RallyxEvents.php
@@ -13,7 +13,6 @@
 
       foreach( $rallyx_events as $event ) {
 ?>
-
         <div class="row">
           <div class="col-md-12">
             <h3 class="text-center">
@@ -49,56 +48,8 @@
 <?php   } ?>
           </div>
         </div>
-
-<?php } ?>
-        <div class="row">
-          <div class="col-md-12">
-
-            <?php
-              $images = Functions::listFiles( "rallycross/carousel", "jpg" );
-              if ( $deviceType != 'phone' ) {
-            ?>
-            <div id="rallyx-carousel" class="carousel slide" data-ride="carousel">
-              <div class="carousel-inner">
-                <?php foreach( $images as $index => $image ) {  ?>
-                <div class="item<?php if ( $index == 0 ) { echo " active"; } ?>">
-                  <img alt="" src="<?php echo baseHref.$image; ?>" />
-                </div>
-                <?php } ?>
-              </div>
-            </div>
-
-            <?php
-              } else {
-                $random = rand(0, sizeof($images)-1);
-            ?>
-            <img class="img-responsive" src="<?php echo baseHref.$images[$random]; ?>" />
-            <?php } ?>
-
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-md-12">
-            <p>
-              RallyX events in Tucson are hosted by the <a href="https://www.facebook.com/AzRallyGroup">Arizona Rally Group</a>
-              at <a href="">MC Motorsports Park</a>. For event details, please visit the
-              <a href="https://www.facebook.com/AzRallyGroup">Facebook page</a>. For a complete list of events, visit the
-              <a href="<?php echo baseHref; ?>/rallycross/calendar.html">rallycross event calendar.</a>
-              </p>
-
-            </p>
-            <p class="text-center">
-              <a class="btn btn-primary btn-md" href="http://mcmotorsportspark.com/">
-                MC Motorsports Park
-              </a>
-              <a class="btn btn-primary btn-md" href="https://www.facebook.com/AzRallyGroup" target="_top">
-                <i class="fa fa-facebook"></i>
-              </a>
-            </p>
-          </div>
-        </div>
 <?php
+      }
     } // end function upcoming_block
-
   } // end Class
 ?>

--- a/rallycross/RallyxEvents.php
+++ b/rallycross/RallyxEvents.php
@@ -1,26 +1,56 @@
 <?php
   class RallyxEvents {
 
-    public static function upcoming_block( $deviceType = "unknown" ) {
+    public static function upcoming_block( $deviceType, $orgId, $apiKey ) {
+      $args = array( 'public' => 1 );
+      $json = MindTheCones::getRequest( "events/upcoming/open/", $orgId, $apiKey, $args );
+      $rallyx_events = json_decode( $json, true );
+      if ( empty( $rallyx_events ) ) {
+        $args[ 'limit' ] = 1;
+        $json = MindTheCones::getRequest( "events/upcoming/", $orgId, $apiKey, $args );
+        $rallyx_events = json_decode( $json, true );
+      }
+
+      foreach( $rallyx_events as $event ) {
 ?>
+
         <div class="row">
           <div class="col-md-12">
-            <p>
-              RallyX events in Tucson are hosted by the <a href="https://www.facebook.com/AzRallyGroup">Arizona Rally Group</a>
-              at <a href="">MC Motorsports Park</a>. For event details, please visit the AZRG website or
-              Facebook page.
-            </p>
-            <p class="text-center">
-              <a class="btn btn-primary btn-md" href="http://mcmotorsportspark.com/">
-                MC Motorsports Park
-              </a>
-              <a class="btn btn-primary btn-md" href="https://www.facebook.com/AzRallyGroup" target="_top">
-                <i class="fa fa-facebook"></i>
-              </a>
-            </p>
+            <h3 class="text-center">
+              <?php if( !empty($event['name'])) { echo $event['name']." "; } ?>
+              <?php echo date( "l, F j", $event[ 'date_ts' ] ); ?>
+              at <?php echo $event['site_name']; ?>
+            </h3>
+
+<?php   if ( $event[ 'status' ] == "will open" ) { ?>
+           <h4 class="text-center">
+              Online registration will open:
+              <?php echo date( "l, F j", $event[ 'registration_open_ts' ] ); ?> at
+              <?php echo date( "g:ia", $event[ 'registration_open_ts' ] ); ?>.
+            </h4>
+
+<?php   } else if ( $event[ 'status' ] == "open" ) { ?>
+
+            <h4 class="text-success text-center">
+              Online registration is open now!
+              <a class="btn btn-success" href="<?php echo mtc_url; ?>register/<?php echo $event[ 'id' ]; ?>" target="_top">Register Now</a>
+            </h4>
+            <h5 class="text-center">
+              Online registration closes
+              <?php echo date( "l, F j", $event[ 'registration_close_ts' ] ); ?> at
+              <?php echo date( "g:ia", $event[ 'registration_close_ts' ] ); ?>.
+            </h5>
+
+<?php   } else if ( $event[ 'status' ] == "closed" ) { ?>
+
+            <h4 align="center" class="azbr-alt-color">
+              Online registration is closed.
+            </h4>
+<?php   } ?>
           </div>
         </div>
 
+<?php } ?>
         <div class="row">
           <div class="col-md-12">
 
@@ -45,6 +75,23 @@
             <img class="img-responsive" src="<?php echo baseHref.$images[$random]; ?>" />
             <?php } ?>
 
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-12">
+            <p>
+              RallyX events in Tucson are hosted by the <a href="https://www.facebook.com/AzRallyGroup">Arizona Rally Group</a>
+              at <a href="">MC Motorsports Park</a>. For event details, please visit the
+              <a href="https://www.facebook.com/AzRallyGroup">Facebook page</a>.
+            </p>
+            <p class="text-center">
+              <a class="btn btn-primary btn-md" href="http://mcmotorsportspark.com/">
+                MC Motorsports Park
+              </a>
+              <a class="btn btn-primary btn-md" href="https://www.facebook.com/AzRallyGroup" target="_top">
+                <i class="fa fa-facebook"></i>
+              </a>
+            </p>
           </div>
         </div>
 <?php

--- a/rallycross/RallyxEvents.php
+++ b/rallycross/RallyxEvents.php
@@ -82,7 +82,10 @@
             <p>
               RallyX events in Tucson are hosted by the <a href="https://www.facebook.com/AzRallyGroup">Arizona Rally Group</a>
               at <a href="">MC Motorsports Park</a>. For event details, please visit the
-              <a href="https://www.facebook.com/AzRallyGroup">Facebook page</a>.
+              <a href="https://www.facebook.com/AzRallyGroup">Facebook page</a>. For a complete list of events, visit the
+              <a href="<?php echo baseHref; ?>/rallycross/calendar.html">rallycross event calendar.</a>
+              </p>
+
             </p>
             <p class="text-center">
               <a class="btn btn-primary btn-md" href="http://mcmotorsportspark.com/">

--- a/rallycross/calendar.html
+++ b/rallycross/calendar.html
@@ -1,0 +1,82 @@
+<?php
+  require_once "../common/Common.php";
+
+  Display::open_page();
+
+  MindTheCones::setApiKey( $mtcKeys['AZRG'] );
+  MindTheCones::setOrganizationId( $mtcIds['AZRG'] );
+
+  $calendar_year = 2017;
+
+  $json_string = MindTheCones::getRequest( "events/calendar/".$calendar_year."/", array( 'public' => 1 ));
+  $events = json_decode( $json_string, true );
+?>
+        <h2 class="azbr-color"><?php echo $calendar_year; ?> Rallycross Event Calendar</h2>
+
+        <div class="row">
+          <div class="col-md-8">
+            <div class="well well-sm">
+              <table class="table table-hover">
+                <thead>
+                  <tr>
+                    <th>Event Date</th>
+                    <th>Online Registration</th>
+                  </tr>
+                </thead>
+                <tbody>
+<?php
+  $found_next = false;
+  foreach( $events as $event ) {
+
+    // show the event schedule when registration is open
+    // and after it is closed until the day after the event
+    $past = $event[ 'date_ts' ] + 24*60*60 < time();
+?>
+
+                  <tr>
+                    <td>
+                      <p><?php echo date( "l, F j", $event[ 'date_ts' ] ); ?></p>
+                    </td>
+                    <td>
+                      <div class="row">
+                        <div class="col-md-12">
+
+                          <?php if ( $event[ 'name' ] != "" ) { ?>
+                          <p><em><?php echo $event[ 'name' ]; ?></em></p>
+                          <?php } ?>
+
+                          <?php if ( $event[ 'status' ] == "closed" ) { ?>
+                          <span class="text-danger">
+                            Closed at <?php echo date( "g:ia l, F j", $event[ 'registration_close_ts' ] ); ?>
+                          </span>
+                          <?php } else if ( $event[ 'status' ] == "will open" ) { ?>
+                          <span class="text-info">
+                            Opens at <?php echo date( "g:ia l, F j", $event[ 'registration_open_ts' ] ); ?>
+                          </span>
+                          <?php } else if ( $event[ 'status' ] == "open" ) { ?>
+                          <span class="text-success">
+                            <a class="btn btn-success btn-sm"
+                                href="<?php echo mtc_url; ?>register/<?php echo $event[ 'id' ]; ?>">
+                             Registration is Open!
+                           </a>
+                            Closes at <?php echo date( "g:ia l, F j", $event[ 'registration_close_ts' ] ); ?>
+                          </span>
+                          <?php } ?>
+
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                  <?php } ?>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="col-md-4">
+          </div>
+
+        </div>
+<?php
+  Display::close_page();
+?>

--- a/rallycross/calendar.html
+++ b/rallycross/calendar.html
@@ -3,12 +3,8 @@
 
   Display::open_page();
 
-  MindTheCones::setApiKey( $mtcKeys['AZRG'] );
-  MindTheCones::setOrganizationId( $mtcIds['AZRG'] );
-
   $calendar_year = 2017;
-
-  $json_string = MindTheCones::getRequest( "events/calendar/".$calendar_year."/", array( 'public' => 1 ));
+  $json_string = MindTheCones::getRequest( "events/calendar/".$calendar_year."/", $mtcIds['AZRG'], $mtcKeys['AZRG'], array( 'public' => 1 ));
   $events = json_decode( $json_string, true );
 ?>
         <h2 class="azbr-color"><?php echo $calendar_year; ?> Rallycross Event Calendar</h2>


### PR DESCRIPTION
## Why are we doing this?

Received requests from Arizona Rally Group and the Sierra Sports Car Club to display links to their events and registration for said events when open; these clubs use AZBR sanctioning.

This PR adds several things to complete this, as well as making some under the hood changes in support:
* rallycross 'block' on the front page moves to the top of the right column
* rallycross 'block' shows next event with registration link when applicable
* _Sierra Vista Autocross_ block added under renamed _Tucson Autocross_ block in the left column; the _Sierra Vista Autocross_ block shows the next event with registration link when applicable
* moved the function that renders image carousels to the _Display_ class
* moved some static content from the _AutoxEvents_ and _RallyxEvents_ classes to the front page

## How can someone view these changes?

Live now on the [dev site](http://dev.azbrscca.org/). New _rallycross event calendar_ page is [here](http://dev.azbrscca.org/rallycross/calendar.html).

![screen shot 2017-04-16 at 8 30 49 pm](https://cloud.githubusercontent.com/assets/1305168/25076191/1381fd96-22e4-11e7-9629-60574dfb13c3.png)

* test front page to ensure _next event_ is showing correctly for each organization
* test _autocross event calendar_ page to ensure listing is correct
* test **new** _rallycross event calendar_ page to ensure listing is correct
* test _autocross results_ page_: underlying AJAX calls were modified
* test _autocross course map archive_: underlying AJAX calls were modified 

## What possible risks or adverse effects are there?

The multi-organization support is not all that clean, but does get rid of some ugliness in the _MindTheCones_ integration class.

## What are the follow-up tasks?

* test things in _dev_ and deploy to the live site

## Are there any known issues?

None identified.