### PR TITLE
Fixing some broken results and PAX tool things

### DIFF
--- a/autocross/AutoxEvents.php
+++ b/autocross/AutoxEvents.php
@@ -62,7 +62,6 @@
                     <select class="form-control" id="classes" name="classes[]" multiple="multiple" size="4">
                     </select>
                   </div>
-
                   <div class="form-group">
                     <label for="categories">Categories to Display:</label>
                     <select class="form-control" id="categories" name="categories[]" multiple="multiple" size="4">

--- a/autocross/pax.html
+++ b/autocross/pax.html
@@ -3,10 +3,10 @@
 
   Display::open_page();
 
-  $json_string = MindTheCones::getRequest( "classes/" );
+  $json_string = MindTheCones::getRequest( "classes/", $mtcIds['AZBR'], $mtcKeys['AZBR'] );
   $scca_classes = json_decode( $json_string, true );
 
-  $json_string = MindTheCones::getRequest( "classes/types" );
+  $json_string = MindTheCones::getRequest( "classes/types", $mtcIds['AZBR'], $mtcKeys['AZBR'] );
   $class_types = json_decode( $json_string, true );
 
   $pax_lookup = array();

--- a/autocross/results/download.html
+++ b/autocross/results/download.html
@@ -5,11 +5,10 @@
 
   if ( !empty( $_POST ) ) {
     $args = Functions::cleanArray( $_POST );
-
 		if ( $args[ 'type' ] == "series" ) {
-			series_results_spreadsheet( $args[ 'id' ] );
+			series_results_spreadsheet( $args[ 'id' ], $mtcIds['AZBR'], $mtcKeys['AZBR'] );
 		} else if ( $args[ 'type' ] == "event" ) {
-			event_results_spreadsheet( $args[ 'id' ] );
+			event_results_spreadsheet( $args[ 'id' ], $mtcIds['AZBR'], $mtcKeys['AZBR'] );
 		}
   }
 
@@ -36,13 +35,12 @@
 		}
 	}
 
-  function event_results_spreadsheet( $eventId ) {
-
-    $data = MindTheCones::getRequest( "db/events/".$eventId."/", $mtcIds['AZBR], $mtcKeys['AZBR'] );
+  function event_results_spreadsheet( $eventId, $mtcId, $mtcKey ) {
+    $data = MindTheCones::getRequest( "db/events/".$eventId."/", $mtcId, $mtcKey );
     $event = json_decode( $data, true );
-
-    $data = MindTheCones::getRequest( "results/event/".$eventId."/", $mtcIds['AZBR], $mtcKeys['AZBR'] );
+    $data = MindTheCones::getRequest( "results/event/".$eventId."/", $mtcId, $mtcKey );
     $jsonData = json_decode( $data, true );
+
 
     $results = array(
     	"PAX" => array(),
@@ -56,6 +54,12 @@
     foreach( $jsonData as $item ) {
       array_push( $results[ $item[ 'category' ] ], $item );
     }
+
+		foreach( array_keys($results) as $category ) {
+			if ( sizeof($results[$category]) == 0 ) {
+			  unset($results[$category]);
+		  }
+	  }
 
     usort( $results[ 'Open' ], 'sortByClass' );
 
@@ -161,12 +165,12 @@
 <?php
   }
 
-  function series_results_spreadsheet( $seriesId ) {
+  function series_results_spreadsheet( $seriesId, $mtcId, $mtcKey ) {
 
-    $data = MindTheCones::getRequest("db/series/".$seriesId."/", $mtcIds['AZBR], $mtcKeys['AZBR']);
+    $data = MindTheCones::getRequest("db/series/".$seriesId."/", $mtcId, $mtcKey);
     $series = json_decode( $data, true );
 
-    $data = MindTheCones::getRequest("results/series/".$seriesId."/", $mtcIds['AZBR], $mtcKeys['AZBR']);
+    $data = MindTheCones::getRequest("results/series/".$seriesId."/", $mtcId, $mtcKey);
     $results = json_decode( $data, true );
 
     header("Content-type: application/vnd.ms-excel");
@@ -198,8 +202,14 @@
               </thead>
               <tbody>
 <?php
-
+		$with_results = array_keys($results[ 'categories' ]);
+		foreach( $categories as $category ) {
+			if (!in_array($category, $with_results)) {
+				unset($categories[array_search($category, $categories)]);
+			}
+		}
     foreach( $categories as $category ) {
+
 
       if ( !empty( $results[ 'categories' ][ $category ][ 'divided' ] ) ) {
         unset( $results[ 'categories' ][ $category ][ 'divided' ] );

--- a/js/azbr/autocross/results.js
+++ b/js/azbr/autocross/results.js
@@ -43,10 +43,10 @@ rbc[ result.category ].push( result );
       });
 
       $.each( categories, function( index, category ) {
-
 var showCategory = ( $.inArray( "All", selectedCategories ) >= 0 );
 showCategory |= ( ( $.inArray( "Comps", selectedCategories ) >= 0 ) && ( category != "Time Only" ) )
 showCategory |= ( $.inArray( category, selectedCategories ) >= 0 );
+showCategory &= (rbc[category].length > 0);
 if ( showCategory ) {
 
   row = $( "<tr/>" )
@@ -511,8 +511,8 @@ if ( showCategory ) {
   });
 
   $( "#id" ).change( function() {
-//           var selected = $( this ).find( "option:selected" );
-//           var type = $( "#type" ).val( selected.data( 'type' ) );
+   var selected = $( this ).find( "option:selected" );
+   var type = $( "#type" ).val( selected.data( 'type' ) );
     getResults( true );
   });
 


### PR DESCRIPTION
## Why are we doing this?

Bug fixes:
* add necessary arguments to the API call for the PAX tool
* fix use of arguments to API call for the results spreadsheet
* hide categories with no entries - this is a hack to get around the elimination of the _Street Tire_ category

## How can someone view these changes?

These changes are already live - hot fixed then ported back into the repo. Naughty, naughty.

## What possible risks or adverse effects are there?

Well, the hiding of _Street Tire_ works but is admittedly a hack, so there's that. That adds technical debt. Let's be honest though, this entire thing is technical debt.

## What are the follow-up tasks?

* Check into removing _Street Tire_ from the filters drop down when appropriate. Basically, the results set should be checked rather than that listing be hard coded, as it currently is.

## Are there any known issues?

None identified that this introduces.