### PR TITLE
Adding Tire Rack Street Survival information for 2017

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,17 +49,6 @@
                     <p>On November 11th, the Arizona Border Region will host a Tire Rack Street Survival school at Marana Regional Airport.</p>
                     <p>The primary emphasis of the Tire Rack Street Survival® is a "hands-on" driving experience in real-world situations! We use your own car to teach you about its handling limits and how you can control them. The students will become more observant of the traffic situation they find themselves in. They will learn to look far enough ahead to anticipate unwise actions of other drivers. As the students master the application of physics to drive their cars, they will make fewer unwise driving actions themselves. They will understand why they should always wear their own seatbelts, and why they should insist that their passengers wear seatbelts, too.</p>
 										<p>Registration information coming soon!</p>
-                    <!--
-                    <p>The Street Survival school is an all day event, from 8:30am to approximately 3:30pm. Cost per student is $75, lunch on site is included.</p>
-                    <p class="text-center">
-                      <a class="btn btn-primary" href="http://streetsurvival.org/schools/frequently-asked-questions/">
-                        Street Survival FAQ <i class="fa fa-angle-double-right"></i>
-                      </a>
-                      <a class="btn btn-primary" href="https://www.motorsportreg.com/index.cfm/event/register.trss/uidEvent/768199B2-CCFF-B77B-737B2FE6CBB30EC3">
-                        Register! <i class="fa fa-angle-double-right"></i>
-                      </a>
-                    </p>
-                    -->
                   </div>
                 </div>
               </div>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
               </p>
             </div>
             <div data-expires="2017-11-11">
-              <h2 class="azbr-color"><em>Tire Rack Street Survival School - November 11</em></h2>
+              <h2 class="azbr-color"><em>Tire Rack Street Survival - November 11</em></h2>
               <div class="well well-sm">
                 <div class="row">
                   <div class="col-xs-6 col-md-4">
@@ -48,6 +48,7 @@
 
                     <p>On November 11th, the Arizona Border Region will host a Tire Rack Street Survival school at Marana Regional Airport.</p>
                     <p>The primary emphasis of the Tire Rack Street Survival® is a "hands-on" driving experience in real-world situations! We use your own car to teach you about its handling limits and how you can control them. The students will become more observant of the traffic situation they find themselves in. They will learn to look far enough ahead to anticipate unwise actions of other drivers. As the students master the application of physics to drive their cars, they will make fewer unwise driving actions themselves. They will understand why they should always wear their own seatbelts, and why they should insist that their passengers wear seatbelts, too.</p>
+										<p>Registration information coming soon!</p>
                     <!--
                     <p>The Street Survival school is an all day event, from 8:30am to approximately 3:30pm. Cost per student is $75, lunch on site is included.</p>
                     <p class="text-center">

--- a/index.html
+++ b/index.html
@@ -35,6 +35,34 @@
                 For event details and results, please visit <a href="http://sierrasportscars.net/">SierraSportsCars.net</a>.
               </p>
             </div>
+            <div data-expires="2017-11-11">
+              <h2 class="azbr-color"><em>Tire Rack Street Survival School - November 11</em></h2>
+              <div class="well well-sm">
+                <div class="row">
+                  <div class="col-xs-6 col-md-4">
+                    <a href="http://www.azbrscca.org/about/" class="thumbnail">
+                      <img class="img-responsive" src="http://www.azbrscca.org/images/trss_logo.png" />
+                    </a>
+                  </div>
+                  <div class="col-xs-6 col-md-8">
+
+                    <p>On November 11th, the Arizona Border Region will host a Tire Rack Street Survival school at Marana Regional Airport.</p>
+                    <p>The primary emphasis of the Tire Rack Street Survival® is a "hands-on" driving experience in real-world situations! We use your own car to teach you about its handling limits and how you can control them. The students will become more observant of the traffic situation they find themselves in. They will learn to look far enough ahead to anticipate unwise actions of other drivers. As the students master the application of physics to drive their cars, they will make fewer unwise driving actions themselves. They will understand why they should always wear their own seatbelts, and why they should insist that their passengers wear seatbelts, too.</p>
+                    <!--
+                    <p>The Street Survival school is an all day event, from 8:30am to approximately 3:30pm. Cost per student is $75, lunch on site is included.</p>
+                    <p class="text-center">
+                      <a class="btn btn-primary" href="http://streetsurvival.org/schools/frequently-asked-questions/">
+                        Street Survival FAQ <i class="fa fa-angle-double-right"></i>
+                      </a>
+                      <a class="btn btn-primary" href="https://www.motorsportreg.com/index.cfm/event/register.trss/uidEvent/768199B2-CCFF-B77B-737B2FE6CBB30EC3">
+                        Register! <i class="fa fa-angle-double-right"></i>
+                      </a>
+                    </p>
+                    -->
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
 
           <div class="col-md-5">


### PR DESCRIPTION
## Why are we doing this?

Adds the basic information for the school, taking place on November 11.

## How can someone view these changes?

[Dev Site](http://dev.azbrscca.org/) - left column under Sierra Vista autocross

## What possible risks or adverse effects are there?

Date is not yet on the [TRSS](http://streetsurvival.org/register) website..?

## What are the follow-up tasks?

Add registration link when it is available.

## Are there any known issues?

None.