### PR TITLE
Move July and September meetings back a week

### DIFF
--- a/about/Meetings.php
+++ b/about/Meetings.php
@@ -30,9 +30,8 @@
 
     /***** add rescheduled dates below *****/
     private static $rescheduled_to = array(
-      "2013-01-01",
-      "2014-06-10",
-      "2014-09-09",
+      "2017-07-11",
+      "2017-09-12",
     );
 
 


### PR DESCRIPTION
## Why are we doing this?

Update two upcoming meetings to avoid conflicts:
* July: moved from the 4th (holiday) to the 11th
* September: moved from the 5th (Nationals) to the 12th

## How can someone view these changes?

[Dev Site](http://dev.azbrscca.org/)

## What possible risks or adverse effects are there?

None.

## What are the follow-up tasks?

Go live.

## Are there any known issues?

None.