### PR TITLE
Add SCCA Starting Line School information

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,19 +13,6 @@
 ?>
         <div class="row">
           <div class="col-md-7">
-            <h2 class="azbr-color"><em>Tucson Autocross</em></h2>
-            <div class="well well-sm">
-              <?php AutoxEvents::upcoming_block( $deviceType, $mtcIds['AZBR'], $mtcKeys['AZBR'] ); ?>
-              <?php Display::image_carousel( "autocross/carousel"); ?>
-              <p>
-                Please refer to the <a href="<?php echo baseHref; ?>autocross/calendar.html">event calendar</a>
-                for event schedules and run/work order.
-              </p>
-            </div>
-            <div class="well well-sm">
-              <?php AutoxEvents::past_tabs( $mtcIds['AZBR'], $mtcKeys['AZBR'] ); ?>
-            </div>
-
             <h2 class="azbr-color"><em>Starting Line Autocross School</em></h2>
             <div class="well well-sm">
               <p>
@@ -46,6 +33,19 @@
                   Register Now
                 </a>
               </p>
+            </div>
+
+            <h2 class="azbr-color"><em>Tucson Autocross</em></h2>
+            <div class="well well-sm">
+              <?php AutoxEvents::upcoming_block( $deviceType, $mtcIds['AZBR'], $mtcKeys['AZBR'] ); ?>
+              <?php Display::image_carousel( "autocross/carousel"); ?>
+              <p>
+                Please refer to the <a href="<?php echo baseHref; ?>autocross/calendar.html">event calendar</a>
+                for event schedules and run/work order.
+              </p>
+            </div>
+            <div class="well well-sm">
+              <?php AutoxEvents::past_tabs( $mtcIds['AZBR'], $mtcKeys['AZBR'] ); ?>
             </div>
 
             <h2 class="azbr-color"><em>Sierra Vista Autocross</em></h2>

--- a/index.html
+++ b/index.html
@@ -26,6 +26,28 @@
               <?php AutoxEvents::past_tabs( $mtcIds['AZBR'], $mtcKeys['AZBR'] ); ?>
             </div>
 
+            <h2 class="azbr-color"><em>Starting Line Autocross School</em></h2>
+            <div class="well well-sm">
+              <p>
+                On Saturday, February 24, the Arizona Border Region hosts an SCCA Starting Line
+                Autocross School at Marana Regional Airport.
+              </p>
+              <p>
+                This full day school will introduce key concepts that introduce you to autocross
+                and the dynamics of your vehicle in a performance driving setting.  While the focus
+                is on autocross, you will develop performance driving skills while working with
+                professional performance driving instructors.
+              </p>
+              <p class="text-center">
+                <a class="btn btn-primary btn-md" href="https://www.scca.com/pages/sl-autocross" target="_top">
+                  More Information
+                </a>
+                <a class="btn btn-success" href="https://www.scca.com/events/1990932-starting-line-tuscon" target="_top">
+                  Register Now
+                </a>
+              </p>
+            </div>
+
             <h2 class="azbr-color"><em>Sierra Vista Autocross</em></h2>
             <div class="well well-sm">
               <?php AutoxEvents::upcoming_block( $deviceType, $mtcIds['SSCC'], $mtcKeys['SSCC'] ); ?>
@@ -56,11 +78,11 @@
                 and hills of Arizona. Expect moderate average speeds, passage controls, no DIYC’s, and paved roads. The
                 beauty of the countryside and the entertainment value of the roads will surprise you.
               </p>
-
-              <a class="btn btn-primary btn-md" href="<?php echo baseHref; ?>documents/forms/rally_entry_mar2018.docx">
-                Entry Form
-              </a>
-
+              <p class="text-center">
+                <a class="btn btn-primary btn-md" href="<?php echo baseHref; ?>documents/forms/rally_entry_mar2018.docx">
+                  Entry Form
+                </a>
+              </p>
             </div>
 
           </div>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
           <div class="col-md-7">
             <h2 class="azbr-color"><em>Starting Line Autocross School</em></h2>
             <div class="well well-sm">
+              <img class="img-responsive" src="https://dk1xgl0d43mu1.cloudfront.net/user_files/scca/site_assets/000/021/980/original.jpg?1487900782" />
               <p>
                 On Saturday, February 24, the Arizona Border Region hosts an SCCA Starting Line
                 Autocross School at Marana Regional Airport.


### PR DESCRIPTION
## Why are we doing this?

Adding a block containing information and links for the Starting Line School taking place on February 24.

## How can someone view these changes?

Visit the [dev site](http://dev.azbrscca.org/).

<img width="688" alt="screen shot 2018-01-23 at 4 07 11 pm" src="https://user-images.githubusercontent.com/1305168/35303459-a2bd0c66-0057-11e8-8e72-5e12aa37b66e.png">

## What possible risks or adverse effects are there?

None identified.

## What are the follow-up tasks?

Review it on the dev site and push it to the live site.

## Are there any known issues?

None.
