### PR TITLE
Remove Starting Line school now that it is over

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,35 +13,6 @@
 ?>
         <div class="row">
           <div class="col-md-7">
-            <h2 class="azbr-color"><em>Starting Line Autocross School</em></h2>
-            <div class="well well-sm">
-              <img class="img-responsive" src="<?php echo baseHref; ?>images/starting_line/banner.jpg" />
-              <p class="text-center">
-                On Saturday, February 24, the Arizona Border Region hosts an SCCA Starting Line
-                Autocross School at Marana Regional Airport.
-              </p>
-              <div class="row">
-                <div class="col-xs-4 col-md-5">
-                  <a href="https://www.scca.com/pages/sl-autocross" target="_top">
-                    <img class="img-responsive" src="<?php echo baseHref; ?>images/starting_line/learn_more.jpg" />
-                  </a>
-                </div>
-                <div class="col-xs-8 col-md-7">
-                  <p>
-                    This full day school will introduce key concepts that introduce you to autocross
-                    and the dynamics of your vehicle in a performance driving setting.  While the focus
-                    is on autocross, you will develop performance driving skills while working with
-                    professional performance driving instructors.
-                  </p>
-                  <p class="text-center">
-                    <a class="btn btn-success" href="https://www.scca.com/events/1990932-starting-line-tuscon" target="_top">
-                      Register Now
-                    </a>
-                  </p>
-                </div>
-              </div>
-            </div>
-
             <h2 class="azbr-color"><em>Tucson Autocross</em></h2>
             <div class="well well-sm">
               <?php AutoxEvents::upcoming_block( $deviceType, $mtcIds['AZBR'], $mtcKeys['AZBR'] ); ?>


### PR DESCRIPTION
## Why are we doing this?

Removing details for a past event from the front page.

## How can someone view these changes?

Dev site.

<img width="1167" alt="screen shot 2018-02-28 at 5 38 24 pm" src="https://user-images.githubusercontent.com/1305168/36819313-a60ee81c-1cae-11e8-8dbf-69d0175c1a75.png">

## What possible risks or adverse effects are there?

None identified

## What are the follow-up tasks?

Merge.
Push merged changes to dev to double check.
Push to live.

## Are there any known issues?

Nizope!