### PR TITLE
Add Video from SASCA event for Vet Motorsports

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
                 site below.
               </p>
               <p>
-                <iframe width="560" height="315" src="https://www.youtube.com/embed/fO3258yMHRw?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+                <iframe src="https://www.youtube.com/embed/fO3258yMHRw?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
               </p>
               <p class="text-center">
                 <a class="btn btn-primary btn-md" href="http://www.vetmotorsports.org/">

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
                 heal and move forward. You can find more information at the web
                 site below.
               </p>
-              <p>
+              <p class="text-center">
                 <iframe src="https://www.youtube.com/embed/fO3258yMHRw?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
               </p>
               <p class="text-center">

--- a/index.html
+++ b/index.html
@@ -123,7 +123,13 @@
                 heal and move forward. You can find more information at the web
                 site below.
               </p>
+              <p>
+                VETMotorsports placed injured warfighters behond the wheel in Selma, TX this past March.
+                Below is the in-car footage with a Air Force veteran behind the wheel with an Army Veteran 
+                as his co-driver.
+              </p>
               <p class="text-center">
+                
                 <iframe src="https://www.youtube.com/embed/fO3258yMHRw?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
               </p>
               <p class="text-center">

--- a/index.html
+++ b/index.html
@@ -123,6 +123,9 @@
                 heal and move forward. You can find more information at the web
                 site below.
               </p>
+              <p>
+                <iframe width="560" height="315" src="https://www.youtube.com/embed/fO3258yMHRw?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+              </p>
               <p class="text-center">
                 <a class="btn btn-primary btn-md" href="http://www.vetmotorsports.org/">
                   VetMotorsports


### PR DESCRIPTION
## Why are we doing this?

Vet Motorsports sent a video of participants in their program running in an event in San Antonio and thought it would be a good item to add to the information about their program on our page.

## How can someone view these changes?

Currently deployed on the [dev site](http://dev.azbrscca.org/).

## What possible risks or adverse effects are there?

YouTube embeds video via an `iframe` which can be difficult to display in responsive sites so I have left the `height` and `width` out so they will auto-scale. This results in the video showing up on the small side, but there is the option for the user to view it full screen.

## What are the follow-up tasks?

- merge to `master`
- push updated `master` to the dev site for final verification
- push updated `master` to the live site

## Are there any known issues?

None identified.