### PR TITLE
Restore common functions so that results downloads work again

### DIFF
--- a/common/Functions.php
+++ b/common/Functions.php
@@ -15,6 +15,27 @@
       return $files;
     }
 
+    public static function cleanArray( $dirtyArray ) {	+    private static function removePrefix( &$item, $index, $start) {
+      $cleanArray = array();	+      $item = substr( $item, $start );
+      foreach( array_keys( $dirtyArray ) as $key ) {
+        if ( is_array( $dirtyArray[ $key ] ) ) {
+          $cleanArray[ $key ] = self::cleanArray( $dirtyArray[ $key ] );
+        } else {	
+          $cleanArray[ $key ] = self::cleanString( $dirtyArray[ $key ] );
+        }
+      }
+      return $cleanArray;
+    }
+
+    public static function cleanString( $dirty ) {
+      $clean = mb_convert_encoding( $dirty, 'UTF-8', 'UTF-8' );
+      $clean = htmlentities( $clean, ENT_QUOTES, 'UTF-8' );
+      $clean = htmlspecialchars_decode( $clean );
+      $clean = preg_replace( "/&#039;/", "'", $clean );
+      $clean = preg_replace( "/&quot;/", "\"", $clean );
+      return $clean;
+    }
+
     private static function removePrefix( &$item, $index, $start) {
       $item = substr( $item, $start );
     }

--- a/common/Functions.php
+++ b/common/Functions.php
@@ -15,12 +15,12 @@
       return $files;
     }
 
-    public static function cleanArray( $dirtyArray ) {	+    private static function removePrefix( &$item, $index, $start) {
-      $cleanArray = array();	+      $item = substr( $item, $start );
+    public static function cleanArray( $dirtyArray ) {
+      $item = substr( $item, $start );
       foreach( array_keys( $dirtyArray ) as $key ) {
         if ( is_array( $dirtyArray[ $key ] ) ) {
           $cleanArray[ $key ] = self::cleanArray( $dirtyArray[ $key ] );
-        } else {	
+        } else {
           $cleanArray[ $key ] = self::cleanString( $dirtyArray[ $key ] );
         }
       }


### PR DESCRIPTION
## Why are we doing this?

Closes #33 

With #30, I neglected to notice that the `cleanArray` function, and the `cleanString` function it uses, are needed for the results download to work correctly. A user reported seeing a PHP error when attempting to download results. This PR restores those functions so that the results download works again.

## How can someone view these changes?

_Problem Example_
- Go to http://www.azbrscca.org/autocross/results.html
- Click the _Download Results_ button
- PHP error!
```
Fatal error: Call to undefined method Functions::cleanArray() in /homepages/12/d270970334/htdocs/live.azbrscca.org/autocross/results/download.html on line 7
```

_Solution Example_
- Go to http://dev.azbrscca.org/autocross/results.html
- Click the _Download Results_ button
- Success! The file downloads and can be opened in Excel or OpenOffice

## What possible risks or adverse effects are there?

Nothin'. I thought these functions were dead and unused but clearly my skills with `grep` need work.

## What are the follow-up tasks?

Push it to prod, maybe notify the user (Scott Meyers) it was fixed.

## Are there any known issues?

Nope!
