### PR TITLE
2018 trss

### DIFF
--- a/about/Meetings.php
+++ b/about/Meetings.php
@@ -30,8 +30,7 @@
 
     /***** add rescheduled dates below *****/
     private static $rescheduled_to = array(
-      "2017-07-11",
-      "2017-09-12",
+      "2018-09-11",
     );
 
 

--- a/front-page-fragments.html
+++ b/front-page-fragments.html
@@ -81,7 +81,7 @@
 
 
             <div>
-              <h2 class="azbr-color"><em>Tire Rack Street Survival School - November 5</em></h2>
+              <h2 class="azbr-color"><em>Tire Rack Street Survival School - November10</em></h2>
               <div class="well well-sm">
                 <div class="row">
                   <div class="col-xs-6 col-md-4">
@@ -91,7 +91,7 @@
                   </div>
                   <div class="col-xs-6 col-md-8">
 
-                    <p>On November 5th, the Arizona Border Region will host a Tire Rack Street Survival school at Marana Regional Airport.</p>
+                    <p>On November 10th, the Arizona Border Region will host a Tire Rack Street Survival school at Marana Regional Airport.</p>
                     <p>The primary emphasis of the Tire Rack Street Survival® is a "hands-on" driving experience in real-world situations! We use your own car to teach you about its handling limits and how you can control them. The students will become more observant of the traffic situation they find themselves in. They will learn to look far enough ahead to anticipate unwise actions of other drivers. As the students master the application of physics to drive their cars, they will make fewer unwise driving actions themselves. They will understand why they should always wear their own seatbelts, and why they should insist that their passengers wear seatbelts, too.</p>
 
                     <p>The Street Survival school is an all day event, from 8:30am to approximately 3:30pm. Cost per student is $95, lunch on site is included.</p>

--- a/front-page-fragments.html
+++ b/front-page-fragments.html
@@ -94,13 +94,13 @@
                     <p>On November 5th, the Arizona Border Region will host a Tire Rack Street Survival school at Marana Regional Airport.</p>
                     <p>The primary emphasis of the Tire Rack Street Survival® is a "hands-on" driving experience in real-world situations! We use your own car to teach you about its handling limits and how you can control them. The students will become more observant of the traffic situation they find themselves in. They will learn to look far enough ahead to anticipate unwise actions of other drivers. As the students master the application of physics to drive their cars, they will make fewer unwise driving actions themselves. They will understand why they should always wear their own seatbelts, and why they should insist that their passengers wear seatbelts, too.</p>
 
-                    <p>The Street Survival school is an all day event, from 8:30am to approximately 3:30pm. Cost per student is $75, lunch on site is included.</p>
+                    <p>The Street Survival school is an all day event, from 8:30am to approximately 3:30pm. Cost per student is $95, lunch on site is included.</p>
               
                     <p class="text-center">
                       <a class="btn btn-primary" href="http://streetsurvival.org/schools/frequently-asked-questions/">
                         Street Survival FAQ <i class="fa fa-angle-double-right"></i>
                       </a>
-                      <a class="btn btn-primary" href="https://www.motorsportreg.com/index.cfm/event/register.trss/uidEvent/768199B2-CCFF-B77B-737B2FE6CBB30EC3">
+                      <a class="btn btn-primary" href="https://www.motorsportreg.com/events/arizona-border-scca-18-1-marana-regional-airport-tire-rack-street-survival-944928">
                         Register! <i class="fa fa-angle-double-right"></i>
                       </a>
                     </p>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 ?>
         <div class="row">
           <div class="col-md-7">
-              <h2 class="azbr-color"><em>Tire Rack Street Survival School - November 10</em></h2>
+              <h2 class="azbr-color"><em>Tire Rack Street Survival School November 10</em></h2>
               <div class="well well-sm">
                 <div class="row">
                   <div class="col-xs-6 col-md-4">

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 ?>
         <div class="row">
           <div class="col-md-7">
-              <h2 class="azbr-color"><em>Tire Rack Street Survival School - November 5</em></h2>
+              <h2 class="azbr-color"><em>Tire Rack Street Survival School - November 10</em></h2>
               <div class="well well-sm">
                 <div class="row">
                   <div class="col-xs-6 col-md-4">
@@ -19,7 +19,7 @@
                   </div>
                   <div class="col-xs-6 col-md-8">
 
-                    <p>On November 5th, the Arizona Border Region will host a Tire Rack Street Survival school at Marana Regional Airport.</p>
+                    <p>On November 10th, the Arizona Border Region will host a Tire Rack Street Survival school at Marana Regional Airport.</p>
                     <p>The primary emphasis of the Tire Rack Street Survival® is a "hands-on" driving experience in real-world situations! We use your own car to teach you about its handling limits and how you can control them. The students will become more observant of the traffic situation they find themselves in. They will learn to look far enough ahead to anticipate unwise actions of other drivers. As the students master the application of physics to drive their cars, they will make fewer unwise driving actions themselves. They will understand why they should always wear their own seatbelts, and why they should insist that their passengers wear seatbelts, too.</p>
 
                     <p>The Street Survival school is an all day event, from 8:30am to approximately 3:30pm. Cost per student is $95, lunch on site is included.</p>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,32 @@
 ?>
         <div class="row">
           <div class="col-md-7">
+              <h2 class="azbr-color"><em>Tire Rack Street Survival School - November 5</em></h2>
+              <div class="well well-sm">
+                <div class="row">
+                  <div class="col-xs-6 col-md-4">
+                    <a href="http://www.azbrscca.org/about/" class="thumbnail">
+                      <img class="img-responsive" src="http://www.azbrscca.org/images/trss_logo.png" />
+                    </a>
+                  </div>
+                  <div class="col-xs-6 col-md-8">
+
+                    <p>On November 5th, the Arizona Border Region will host a Tire Rack Street Survival school at Marana Regional Airport.</p>
+                    <p>The primary emphasis of the Tire Rack Street Survival® is a "hands-on" driving experience in real-world situations! We use your own car to teach you about its handling limits and how you can control them. The students will become more observant of the traffic situation they find themselves in. They will learn to look far enough ahead to anticipate unwise actions of other drivers. As the students master the application of physics to drive their cars, they will make fewer unwise driving actions themselves. They will understand why they should always wear their own seatbelts, and why they should insist that their passengers wear seatbelts, too.</p>
+
+                    <p>The Street Survival school is an all day event, from 8:30am to approximately 3:30pm. Cost per student is $75, lunch on site is included.</p>
+              
+                    <p class="text-center">
+                      <a class="btn btn-primary" href="http://streetsurvival.org/schools/frequently-asked-questions/">
+                        Street Survival FAQ <i class="fa fa-angle-double-right"></i>
+                      </a>
+                      <a class="btn btn-primary" href="https://www.motorsportreg.com/index.cfm/event/register.trss/uidEvent/768199B2-CCFF-B77B-737B2FE6CBB30EC3">
+                        Register! <i class="fa fa-angle-double-right"></i>
+                      </a>
+                    </p>
+                  </div>
+                </div>
+              </div>
             <h2 class="azbr-color"><em>Tucson Autocross</em></h2>
             <div class="well well-sm">
               <?php AutoxEvents::upcoming_block( $mtcIds['AZBR'], $mtcKeys['AZBR'] ); ?>

--- a/index.html
+++ b/index.html
@@ -22,13 +22,13 @@
                     <p>On November 5th, the Arizona Border Region will host a Tire Rack Street Survival school at Marana Regional Airport.</p>
                     <p>The primary emphasis of the Tire Rack Street Survival® is a "hands-on" driving experience in real-world situations! We use your own car to teach you about its handling limits and how you can control them. The students will become more observant of the traffic situation they find themselves in. They will learn to look far enough ahead to anticipate unwise actions of other drivers. As the students master the application of physics to drive their cars, they will make fewer unwise driving actions themselves. They will understand why they should always wear their own seatbelts, and why they should insist that their passengers wear seatbelts, too.</p>
 
-                    <p>The Street Survival school is an all day event, from 8:30am to approximately 3:30pm. Cost per student is $75, lunch on site is included.</p>
+                    <p>The Street Survival school is an all day event, from 8:30am to approximately 3:30pm. Cost per student is $95, lunch on site is included.</p>
               
                     <p class="text-center">
                       <a class="btn btn-primary" href="http://streetsurvival.org/schools/frequently-asked-questions/">
                         Street Survival FAQ <i class="fa fa-angle-double-right"></i>
                       </a>
-                      <a class="btn btn-primary" href="https://www.motorsportreg.com/index.cfm/event/register.trss/uidEvent/768199B2-CCFF-B77B-737B2FE6CBB30EC3">
+                      <a class="btn btn-primary" href="https://www.motorsportreg.com/events/arizona-border-scca-18-1-marana-regional-airport-tire-rack-street-survival-944928">
                         Register! <i class="fa fa-angle-double-right"></i>
                       </a>
                     </p>


### PR DESCRIPTION
## Why are we doing this?

This year's 2018 Tire Rack Street Survival School is happening in three months, and it's time to update the home page to advertise it. Also, we've rescheduled the September board meeting due to Nationals, so we're updating that too.

## How can someone view these changes?

The dev site currently has the updates: http://dev.azbrscca.org/

## What possible risks or adverse effects are there?

This is a copy-pasted blurb from front-page-fragments.html so the biggest risk is a stray div tag or other HTML issue.

## What are the follow-up tasks?

Remove the information after the event.

## Are there any known issues?

None.
