### PR TITLE
Two days of Awesome 2019

### DIFF
--- a/autocross/details.html
+++ b/autocross/details.html
@@ -101,7 +101,7 @@
                 </li>
                 <li>One (1) portable toilet will be provided (rented by AZBR). Please keep it clean.</li>
                 <li>
-                  The site is an active airport and any FOD (Foreign Object Debri), from a Kleenex to a
+                  The site is an active airport and any FOD (Foreign Object Debris), from a Kleenex to a
                   water bottle, is extremely dangerous to the operating aircraft and to our future use
                   of the site. Contain your own trash and pick up anything you see. There will be a few
                   garbage cans on site. Use those or take trash off site when you leave.

--- a/autocross/paypal.html
+++ b/autocross/paypal.html
@@ -8,6 +8,88 @@
         <div class="row">
           <div class="col-md-12">
             <div class="well well-sm">
+              <h3 class="text-info text-center">Two Days of Awesome - SCCA Member</h3>
+              <p>
+                Select one of these options if you are a full status SCCA member taking advantage of the $10 discount for pre-registering for both days.
+              </p>
+              <div class="row">
+                <div class="col-md-8 col-xs-8">
+                  Two Day Competition Entry + Two TOs - $62
+                </div>
+                <div class="col-md-4 col-xs-2">
+                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                  <input type="hidden" name="cmd" value="_s-xclick">
+                  <input type="hidden" name="hosted_button_id" value="XPXBJSCVJG7J2">
+                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                  </form>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-8 col-xs-8">
+                  Two Day Competition Entry Only - $42
+                </div>
+                <div class="col-md-4 col-xs-2">
+                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                  <input type="hidden" name="cmd" value="_s-xclick">
+                  <input type="hidden" name="hosted_button_id" value="W6EZ2EBECYGTU">
+                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                  </form>
+                </div>
+              </div>
+              
+              <h3 class="text-info text-center">Two Days of Awesome - Non SCCA (Weekend) Member</h3>
+              <p>
+                Select one of these options if you are taking advantage of the $10 discount for pre-registering for both days, but do not have a full time SCCA membership.
+              </p>
+              <div class="alert alert-warning">
+                <p>
+                  The SCCA requires that all event participants be SCCA members.
+                  If you are not an SCCA member a weekend membership is available for an extra $10,
+                  which is included in the Non SCCA entry fees shown below. For the Two Days of
+                  Awesome, this is a single $10 charge that covers both days.
+                </p>
+              </div>
+              <div class="row">
+                <div class="col-md-8 col-xs-8">
+                  Two Day Competition Entry + Two TOs - $72
+                </div>
+                <div class="col-md-4 col-xs-2">
+                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                  <input type="hidden" name="cmd" value="_s-xclick">
+                  <input type="hidden" name="hosted_button_id" value="JS4HT2TZP8MT6">
+                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                  </form>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-8 col-xs-8">
+                  Two Day Competition Entry Only - $52
+                </div>
+                <div class="col-md-4 col-xs-2">
+                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                  <input type="hidden" name="cmd" value="_s-xclick">
+                  <input type="hidden" name="hosted_button_id" value="AXRBR3TQJ623S">
+                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                  </form>
+                </div>
+              </div>
+              
+              <h3 class="text-info text-center">Single Day Entry</h3>
+              <p>
+                Select one of these options if you are paying for a single day event.
+                Please select carefully between "SCCA Member" and "NON SCCA Member" (aka Weekend Member).
+              </p>
+              <div class="alert alert-warning">
+                <p>
+                  The SCCA requires that all event participants be SCCA members.
+                  If you are not an SCCA member a weekend membership is available for an extra $10,
+                  which is included in the Non SCCA entry fees shown below.
+                </p>
+              </div>
               <form class="form" target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                 <input type="hidden" name="cmd" value="_s-xclick">
                 <input type="hidden" name="hosted_button_id" value="HULG4G93TQ6ML">

--- a/autocross/paypal.html
+++ b/autocross/paypal.html
@@ -25,7 +25,7 @@
                   </form>
                 </div>
               </div>
-              <br/><br/>
+              <p/>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
                   Two Day Competition Entry Only - $42
@@ -65,7 +65,7 @@
                   </form>
                 </div>
               </div>
-              <br/><br/>
+              <p/>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
                   Two Day Competition Entry Only - $52

--- a/autocross/paypal.html
+++ b/autocross/paypal.html
@@ -13,10 +13,10 @@
                 Select one of these options if you are a full status SCCA member taking advantage of the $10 discount for pre-registering for both days.
               </p>
               <div class="row">
-                <div class="col-md-4 col-xs-4">
+                <div class="col-md-4 col-xs-6">
                   Two Day Competition Entry + Two TOs - $62
                 </div>
-                <div class="col-md-4 col-xs-4">
+                <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick">
                   <input type="hidden" name="hosted_button_id" value="XPXBJSCVJG7J2">
@@ -25,11 +25,12 @@
                   </form>
                 </div>
               </div>
+              <br/><br/>
               <div class="row">
-                <div class="col-md-4 col-xs-4">
+                <div class="col-md-4 col-xs-6">
                   Two Day Competition Entry Only - $42
                 </div>
-                <div class="col-md-4 col-xs-4">
+                <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick">
                   <input type="hidden" name="hosted_button_id" value="W6EZ2EBECYGTU">
@@ -52,10 +53,10 @@
                 </p>
               </div>
               <div class="row">
-                <div class="col-md-4 col-xs-4">
+                <div class="col-md-4 col-xs-6">
                   Two Day Competition Entry + Two TOs - $72
                 </div>
-                <div class="col-md-4 col-xs-4">
+                <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick">
                   <input type="hidden" name="hosted_button_id" value="JS4HT2TZP8MT6">
@@ -64,11 +65,12 @@
                   </form>
                 </div>
               </div>
+              <br/><br/>
               <div class="row">
-                <div class="col-md-4 col-xs-4">
+                <div class="col-md-4 col-xs-6">
                   Two Day Competition Entry Only - $52
                 </div>
-                <div class="col-md-4 col-xs-4">
+                <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick">
                   <input type="hidden" name="hosted_button_id" value="AXRBR3TQJ623S">
@@ -91,7 +93,7 @@
                 </p>
               </div>
               <div class="row">
-                <div class="col-md-4 col-xs-4">
+                <div class="col-md-6 col-xs-12">
                   <form class="form" target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                     <input type="hidden" name="cmd" value="_s-xclick">
                     <input type="hidden" name="hosted_button_id" value="HULG4G93TQ6ML">

--- a/autocross/paypal.html
+++ b/autocross/paypal.html
@@ -13,7 +13,7 @@
                 Select one of these options if you are a full status SCCA member taking advantage of the $10 discount for pre-registering for both days.
               </p>
               <div class="row">
-                <div class="col-md-8 col-xs-8">
+                <div class="col-md-4 col-xs-2">
                   Two Day Competition Entry + Two TOs - $62
                 </div>
                 <div class="col-md-4 col-xs-2">
@@ -26,7 +26,7 @@
                 </div>
               </div>
               <div class="row">
-                <div class="col-md-8 col-xs-8">
+                <div class="col-md-4 col-xs-2">
                   Two Day Competition Entry Only - $42
                 </div>
                 <div class="col-md-4 col-xs-2">
@@ -52,7 +52,7 @@
                 </p>
               </div>
               <div class="row">
-                <div class="col-md-8 col-xs-8">
+                <div class="col-md-4 col-xs-2">
                   Two Day Competition Entry + Two TOs - $72
                 </div>
                 <div class="col-md-4 col-xs-2">
@@ -65,7 +65,7 @@
                 </div>
               </div>
               <div class="row">
-                <div class="col-md-8 col-xs-8">
+                <div class="col-md-4 col-xs-2">
                   Two Day Competition Entry Only - $52
                 </div>
                 <div class="col-md-4 col-xs-2">

--- a/autocross/paypal.html
+++ b/autocross/paypal.html
@@ -13,10 +13,10 @@
                 Select one of these options if you are a full status SCCA member taking advantage of the $10 discount for pre-registering for both days.
               </p>
               <div class="row">
-                <div class="col-md-4 col-xs-2">
+                <div class="col-md-4 col-xs-4">
                   Two Day Competition Entry + Two TOs - $62
                 </div>
-                <div class="col-md-4 col-xs-2">
+                <div class="col-md-4 col-xs-4">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick">
                   <input type="hidden" name="hosted_button_id" value="XPXBJSCVJG7J2">
@@ -26,10 +26,10 @@
                 </div>
               </div>
               <div class="row">
-                <div class="col-md-4 col-xs-2">
+                <div class="col-md-4 col-xs-4">
                   Two Day Competition Entry Only - $42
                 </div>
-                <div class="col-md-4 col-xs-2">
+                <div class="col-md-4 col-xs-4">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick">
                   <input type="hidden" name="hosted_button_id" value="W6EZ2EBECYGTU">
@@ -52,10 +52,10 @@
                 </p>
               </div>
               <div class="row">
-                <div class="col-md-4 col-xs-2">
+                <div class="col-md-4 col-xs-4">
                   Two Day Competition Entry + Two TOs - $72
                 </div>
-                <div class="col-md-4 col-xs-2">
+                <div class="col-md-4 col-xs-4">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick">
                   <input type="hidden" name="hosted_button_id" value="JS4HT2TZP8MT6">
@@ -65,10 +65,10 @@
                 </div>
               </div>
               <div class="row">
-                <div class="col-md-4 col-xs-2">
+                <div class="col-md-4 col-xs-4">
                   Two Day Competition Entry Only - $52
                 </div>
-                <div class="col-md-4 col-xs-2">
+                <div class="col-md-4 col-xs-4">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick">
                   <input type="hidden" name="hosted_button_id" value="AXRBR3TQJ623S">
@@ -90,20 +90,24 @@
                   which is included in the Non SCCA entry fees shown below.
                 </p>
               </div>
-              <form class="form" target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
-                <input type="hidden" name="cmd" value="_s-xclick">
-                <input type="hidden" name="hosted_button_id" value="HULG4G93TQ6ML">
-                <input type="hidden" name="on0" value="Registration"/>
-                <select class="form-control" name="os0">
-                  <option value="SCCA Member Competition ONLY"<?php if ( $scca_member && !$time_only ) { echo " selected"; } ?>>SCCA Member Competition ONLY, $27.00</option>
-                  <option value="SCCA Member Competition &amp; Time Only"<?php if ( $scca_member && $time_only ) { echo " selected"; } ?>>SCCA Member Competition &amp; Time Only, $37.00</option>
-                  <option value="NON SCCA Member Competition ONLY"<?php if ( !$scca_member && !$time_only ) { echo " selected"; } ?>>NON SCCA Member Competition ONLY, $37.00</option>
-                  <option value="NON SCCA Member Competition &amp; Time Only"<?php if ( !$scca_member && $time_only ) { echo " selected"; } ?>>NON SCCA Member Competition &amp; Time Only, $47.00</option>
-                </select>
-                <input type="hidden" name="currency_code" value="USD">
-                <input type="image" src="https://www.paypalobjects.com/WEBSCR-640-20110429-1/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-                <img alt="" border="0" src="https://www.paypalobjects.com/WEBSCR-640-20110429-1/en_US/i/scr/pixel.gif" width="1" height="1">
-              </form>
+              <div class="row">
+                <div class="col-md-4 col-xs-4">
+                  <form class="form" target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                    <input type="hidden" name="cmd" value="_s-xclick">
+                    <input type="hidden" name="hosted_button_id" value="HULG4G93TQ6ML">
+                    <input type="hidden" name="on0" value="Registration"/>
+                    <select class="form-control" name="os0">
+                      <option value="SCCA Member Competition ONLY"<?php if ( $scca_member && !$time_only ) { echo " selected"; } ?>>SCCA Member Competition ONLY, $27.00</option>
+                      <option value="SCCA Member Competition &amp; Time Only"<?php if ( $scca_member && $time_only ) { echo " selected"; } ?>>SCCA Member Competition &amp; Time Only, $37.00</option>
+                      <option value="NON SCCA Member Competition ONLY"<?php if ( !$scca_member && !$time_only ) { echo " selected"; } ?>>NON SCCA Member Competition ONLY, $37.00</option>
+                      <option value="NON SCCA Member Competition &amp; Time Only"<?php if ( !$scca_member && $time_only ) { echo " selected"; } ?>>NON SCCA Member Competition &amp; Time Only, $47.00</option>
+                    </select>
+                    <input type="hidden" name="currency_code" value="USD">
+                    <input type="image" src="https://www.paypalobjects.com/WEBSCR-640-20110429-1/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                    <img alt="" border="0" src="https://www.paypalobjects.com/WEBSCR-640-20110429-1/en_US/i/scr/pixel.gif" width="1" height="1">
+                  </form>
+                </div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Why are we doing this?

To add Paypal options for the Two Days of Awesome so that prepaid folks don't overpay.

## How can someone view these changes?

dev.azbrscca.org

Steps to manually verify the change:

1. Check the dev site
2. Click the Autocross menu -> Site & Entry Fee Information
3. Click the Pay with Paypal button
4. Click one of the new buttons. Ensure the price in the Paypal cart matches what's advertised
5. Empty your Paypal cart
6. Lather rinse repeat for the other three new buttons
7. Party

## What possible risks or adverse effects are there?

People could Paypal us the wrong amount of money
Possible confusion over the correct amount to pay

## What are the follow-up tasks?

After two days of awesome is complete, and before next event, hide these buttons so they can't be used.

## Are there any known issues?

None
