### PR TITLE
Add ssl to livesite

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The AZBR website is primarily HTML, CSS, and Javascript with a little bit of PHP
 The site relies on [AZBR Registration] for event information on the calendars and the registration information on the front page. Changes made to event dates or registration open &amp; close dates &amp; times appear automatically once saved in AZBR Registration. Events must be _public_ in AZBR Registration to show up on the front page or event calendars on the AZBR site.
 
 [Bootstrap]: http://getbootstrap.com/docs/3.3/
-[AZBR Registration]: http://registration.azbrscca.org/
+[AZBR Registration]: https://registration.azbrscca.org/
 
 ## Terminology
 
@@ -20,9 +20,9 @@ _1and1_: [AZBR's web hosting provider](https://www.1and1.com/).
 
 _bootstrap_: The responsive front-end library that the AZBR site relies on. The AZBR site is using v3.3 and documentation can be found [here](http://getbootstrap.com/docs/3.3/).
 
-_live site_: The real deal. The legit site. The version that is served up to visitors of http://www.azbrscca.org. When `ssh`-ing into the web server, this is found in the `live.azbrscca.org` directory.
+_live site_: The real deal. The legit site. The version that is served up to visitors of https://www.azbrscca.org. When `ssh`-ing into the web server, this is found in the `live.azbrscca.org` directory.
 
- _dev site_: A staging area where changes can be previewed while on the same server with the same configuration as the live site. This is located at http://dev.azbrscca.org and in the `dev.azbrscca.org` subdirectory of the web server.
+ _dev site_: A staging area where changes can be previewed while on the same server with the same configuration as the live site. This is located at https://dev.azbrscca.org and in the `dev.azbrscca.org` subdirectory of the web server.
 
 ## How Do I ...
 
@@ -32,7 +32,7 @@ Many of the course maps (April 2014 and later, to be exact) are not in GitHub, t
 
 ***Create a new page?***
 
-Start with a copy of the `template.html` file at the top level of the site. When rendered in a browser, it looks like [this](http://www.azbrscca.org/template.html). From there, content can be added as _rows_ divs; the template contains a bare bones example of this.
+Start with a copy of the `template.html` file at the top level of the site. When rendered in a browser, it looks like [this](https://www.azbrscca.org/template.html). From there, content can be added as _rows_ divs; the template contains a bare bones example of this.
 
 Each new page must start with importing `common/Common.php` and call `open_page()` so that the header and menu bar renders properly. Each new page must end with a call to `close_page()` so that the content containers and footer are rendered properly.
 

--- a/autocross/awesome.html
+++ b/autocross/awesome.html
@@ -133,8 +133,8 @@
             <div class="well well-sm">
               <h3 class="text-info text-center">Online Registration</h3>
               <p class="text-center"><!--TODO: dates and links-->
-                <a class="btn btn-success" href="http://www.mindthecones.com/register/419">Saturday October 26th</a>
-                <a class="btn btn-success" href="http://www.mindthecones.com/register/420">Sunday October 27th</a>
+                <a class="btn btn-success" href="https://registration.azbrscca.org/register/419">Saturday October 26th</a>
+                <a class="btn btn-success" href="https://registration.azbrscca.org/register/420">Sunday October 27th</a>
               </p>
               <p>
                 Registration for both days closes Thursday, October 24th at 7:00pm.<!--TODO: date-->

--- a/common/Display.php
+++ b/common/Display.php
@@ -147,6 +147,7 @@
                 <li class="dropdown">
                   <a href="#" class="dropdown-toggle" data-toggle="dropdown">Autocross <b class="caret"></b></a>
                   <ul class="dropdown-menu">
+                    <li><a href="https://registration.azbrscca.org">Online Registration</a></li>
                     <li><a href="<?php echo baseHref; ?>autocross/calendar.html">Event Calendar</a></li>
                     <li><a href="<?php echo baseHref; ?>autocross/details.html">Site &amp; Entry Fee Information</a></li>
                     <li><a href="<?php echo baseHref; ?>autocross/supplemental.html">Supplemental Regulations</a></li>
@@ -176,6 +177,7 @@
                 <li class="dropdown">
                   <a href="#" class="dropdown-toggle" data-toggle="dropdown">Rallycross<b class="caret"></b></a>
                   <ul class="dropdown-menu">
+                    <li><a href="https://registration.azbrscca.org">Online Registration</a></li>
                     <li><a href="<?php echo baseHref; ?>rallycross/calendar.html">Event Calendar</a></li>
                     <li><a href="<?php echo baseHref; ?>rallycross/details.html">Site &amp; Entry Fee Information</a></li>
                     <li><a href="<?php echo baseHref; ?>rallycross/supplemental.html">Supplemental Regulations</a></li>

--- a/front-page-fragments.html
+++ b/front-page-fragments.html
@@ -85,8 +85,8 @@
               <div class="well well-sm">
                 <div class="row">
                   <div class="col-xs-6 col-md-4">
-                    <a href="http://www.azbrscca.org/about/" class="thumbnail">
-                      <img class="img-responsive" src="http://www.azbrscca.org/images/trss_logo.png" />
+                    <a href="https://www.azbrscca.org/about/" class="thumbnail">
+                      <img class="img-responsive" src="https://www.azbrscca.org/images/trss_logo.png" />
                     </a>
                   </div>
                   <div class="col-xs-6 col-md-8">

--- a/rallycross/supplemental.html
+++ b/rallycross/supplemental.html
@@ -52,7 +52,7 @@
 
              <h4><strong>Registration</strong></h4>
 
-              <p>Online Pre-registration is done exclusively through <a href="http://registration.azbrscca.org">AZBR Registration</a>. Registering and paying online will save you $10 vs the cost of on-site registration. </p>
+              <p>Online Pre-registration is done exclusively through <a href="https://registration.azbrscca.org">AZBR Registration</a>. Registering and paying online will save you $10 vs the cost of on-site registration. </p>
               <p>Online Pre-registraion for SCCA Members is $45. ($55 for non members)</p>
               <p>On-Site Registration (Cash only) for SCCA Members is $55. ($65 for non members)</p>
               <p>


### PR DESCRIPTION
## Why are we doing this?

We'd like force everyone viewing anything under the azbrscca.org domain through a secure connection. This is especially important now that the club has control over the registration tool, we want people transmitting account passwords securely.

## How can someone view these changes?

https://dev.azbrscca.org
Common.php within dev.azbrscca.org
.htaccess within htdocs

Steps to manually verify the change:

1. Point a browser to http://dev.azbrscca.org. Verify in the address bar that you've been redirected to https://dev.azbrscca.org. Do the same for http://registration.azbrscca.org. Do the same for http://www.azbrscca.org (note, page will not visually load correctly until follow-up tasks complete).
2. Within the dev site, verify all internal (*.azbrscca.org) links within the top nav menus all point to https:// links
3. Examine Common.php for the dev site and confirm no http:// links
4. Examine .htaccess in htdocs to confirm rewrite rules are correctly configured

## What possible risks or adverse effects are there?

The rewrite rules were tricky to set up, in particular many of my earlier iterations would reroute requests to live.azbrscca.org and fail to load anything. It's possible I'm missing a corner case which would cause a dead link.

## What are the follow-up tasks?

1. Update Common.php for the live site
2. Update registration.azbrscca.org similarly to work with https:// links

## Are there any known issues?

1. These changes, along with Common.php and .htaccess changes, may break registration.azbrscca.org.
2. The live site is currently visually broken until we complete followup task number 1.
