### PR TITLE
2021 2da

### DIFF
--- a/about/Meetings.php
+++ b/about/Meetings.php
@@ -2,20 +2,20 @@
   class Meetings {
 
     /*
-      Meetings default to the first Tuesday of the month.
+      Meetings default to the first Wednesday of the month.
       If a meeting is rescheduled, simply add the NEW DATE
       to the $rescheduled_to array below this comment block
       in YYYY-MM-DD format enclosed in quotes and followed
       by a comma.
 
-      For example, the first Tuesday in January of 2013 was the 1st,
+      For example, the first Wednesday in January of 2013 was the 2nd,
       thus the meeting was rescheduled for the 8th:
 
       $rescheduled_to = array(
         "2013-01-08",
       );
 
-      The new date does not have to be a Tuesday.
+      The new date does not have to be a Wednesday.
 
       As many dates as needed can be included, here we
       have the first three meetings of 2013 all on

--- a/autocross/awesome.html
+++ b/autocross/awesome.html
@@ -1,9 +1,11 @@
 <?php
   require_once "../common/Common.php";
+  
+  $yearsRunning = date("Y") - 2013;
 
   Display::open_page();
 ?>
-        <h2 class="azbr-color">Two Days of Awesome - October 24th &amp; 25th</h2><!--TODO: date-->
+        <h2 class="azbr-color">Two Days of Awesome - October 23rd &amp; 24th</h2><!--TODO: date-->
 
         <div class="row">
           <div class="col-md-7">
@@ -35,14 +37,14 @@
 
               </p>
               <p>
-                For the <!--TODO: num years-->8th year running, the Border Region will be running a two day, national tour style
+                For <?php echo $yearsRunning; ?> years running, the Border Region will be running a two day, national tour style
                 event to welcome fall to the Old Pueblo (just don't mind the temps in the 90s...). Both days are
                 open and welcome to anyone at any autox skill level. In fact, there might not be a
                 better introduction to the sport than seat time on back to back days!
               </p>
               <p>
                 The Saturday event does not count towards any AZBR series, only the Two Days of Awesome. The Sunday event counts towards the 
-                Fall <!--TODO: year-->2020 series. Cumulative results for the weekend <em>Awesome Series</em> are made available online. 
+                Fall <?php echo date("Y"); ?> series. Cumulative results for the weekend <em>Awesome Series</em> are made available online. 
                 Entrants can sign up for one or both days and we offer a $10 discount for entrants that are registered and paid for both 
                 days by the close of on site registration on Saturday. To get the discount you can pay via Paypal prior to the close of 
                 online registration or by check or cash at the registration table on Saturday.
@@ -95,8 +97,8 @@
               <h4><strong>Site Information</strong></h4>
               <p>
                 Bring appropriate drinks for all day hydration. Six 12 or 16 ounce water bottles or sport
-                drinks are usually adequate. Due to COVID, the club is unable to supply water this year, so make sure you bring more than you think you need!<!--Although the club provides drinking water on site, it is intended
-                for course workers or as a backup for those that forget to bring drinks or run out.-->
+                drinks are usually adequate. Due to COVID, the club is unable to supply water this year, so make sure you bring more than you think you need! Although the club provides drinking water on site, it is intended
+                for course workers or as a backup for those that forget to bring drinks or run out.
               </p>
 
               <p>
@@ -106,9 +108,10 @@
               <p>No barbeques can be used on site.</p>
 
               <p>
-                <!--There will be no access to the event site on Friday.--> Gates will open on Saturday for participants per the normal <a href="<?php echo baseHref; ?>autocross/calendar.html">event schedule</a>. See camping rule below for local RV/trailer option.
+                There will be no access to the event site on Friday. Gates will open on Saturday for participants per the normal <a href="<?php echo baseHref; ?>autocross/calendar.html">event schedule</a>. See camping rule below for local RV/trailer option.
               </p>
-              
+<!--TODO: Marana or Musselman event? Which camping rules apply?-->
+<!--Musselman info
               <p>
                 Overnight camping may be possible both Friday night and Saturday night for $20/night (no RV hookups available). The
                 club is not coordinating anything here, you will need to contact <a href="https://mhcircuit.com/">Musselman Honda Circuit</a>
@@ -118,8 +121,8 @@
               <p>
                 Another option is the RV park at the Pima County Fairgrounds not far from the site. This is $30/night with a 50A RV hookup,
                 but spots are first come first served (no reservations) and there are events at the Fairgrounds this weekend.
-              </p>
-<!-- Marana specific info
+              </p>-->
+<!-- Marana specific info-->
               <p>
                 Overnight parking of cars and trailers is permitted on site. They must be located in the dirt/gravel area
                 between the event pavement and the inner fence. The site will be locked over night with no access from the time
@@ -134,7 +137,7 @@
                 See highlighted area below. The airport cafe, also near the entrance, opens at 6:00 AM, has good food,
                 and is fast to serve.
               </p>
-              <img class="img-responsive" src="<?php echo baseHref;?>images/awesome/two_day_airport_parking.png" />-->
+              <img class="img-responsive" src="<?php echo baseHref;?>images/awesome/two_day_airport_parking.png" />
             </div>
           </div>
 
@@ -142,11 +145,11 @@
             <div class="well well-sm">
               <h3 class="text-info text-center">Online Registration</h3>
               <p class="text-center"><!--TODO: dates and links-->
-                <a class="btn btn-success" href="https://registration.azbrscca.org/register/451">Saturday October 24th</a>
-                <a class="btn btn-success" href="https://registration.azbrscca.org/register/452">Sunday October 25th</a>
+                <a class="btn btn-success" href="https://registration.azbrscca.org/register/484">Saturday October 23rd</a>
+                <a class="btn btn-success" href="https://registration.azbrscca.org/register/485">Sunday October 24th</a>
               </p>
               <p>
-                Registration for both days closes Thursday, October 22nd at 7:00pm.<!--TODO: date-->
+                Registration for both days closes Thursday, October 21st at 7:00pm.<!--TODO: date-->
               </p>
             </div>
 
@@ -261,7 +264,8 @@
               </div>
 
             </div>
-<!-- marana local businesses
+<!--TODO: is this a marana event?-->
+<!-- marana local businesses-->
             <div class="well well-sm">
               <h3 class="text-info text-center">Local Businesses</h3>
               <p>For anyone visiting the site for the first time or staying in Marana near the site,
@@ -312,7 +316,7 @@
                 <li>La Olla Mexican Cafe, 8553 North Silverbell Road</li>
                 <li>The Station Bar & Grill, 8235 North Silverbell Road</li>
               </ul>
-            </div>-->
+            </div>
           </div>
         </div>
 

--- a/autocross/awesome.html
+++ b/autocross/awesome.html
@@ -1,7 +1,7 @@
 <?php
   require_once "../common/Common.php";
   
-  $yearsRunning = date("Y") - 2013;
+  $yearsRunning = date("Y") - 2012;   //First year was in 2013. For proper counting/subtraction, 2012 is the "zero" point.
 
   Display::open_page();
 ?>

--- a/index.html
+++ b/index.html
@@ -32,12 +32,38 @@
                   </div>
                 </div>
               </div>
-            <h2 class="azbr-color"><em>Tire Rack Street Survival - November 7th</em></h2>
-            <div class="well well-sm">
-              <p>
-                We are planning to hold a Tire Rack Street Survival event on Sunday, November 7th at Marana Regional Airport. Stay tuned for more information coming soon...
-              </p>
-            </div>
+            <h2 class="azbr-color"><em>Tire Rack Street Survival School - November <!--TODO: date-->7</em></h2>
+              <div class="well well-sm">
+                <div class="row">
+                  <div class="col-xs-6 col-md-4">
+                    <a href="https://www.azbrscca.org/about/" class="thumbnail">
+                      <img class="img-responsive" src="https://www.azbrscca.org/images/trss_logo.png" />
+                    </a>
+                  </div>
+                  <div class="col-xs-6 col-md-8">
+
+                    <p>On November <!--TODO: date-->7th, the Arizona Border Region will host a Tire Rack Street Survival school at Marana Regional Airport.</p>
+
+                    <p>The primary emphasis of the Tire Rack Street Survival® is a "hands-on" driving experience in real-world situations! 
+                    We use your own car to teach you about its handling limits and how you can control them. The students will become more observant 
+                    of the traffic situation they find themselves in. They will learn to look far enough ahead to anticipate unwise actions of other 
+                    drivers. As the students master the application of physics to drive their cars, they will make fewer unwise driving actions 
+                    themselves. They will understand why they should always wear their own seatbelts, and why they should insist that their 
+                    passengers wear seatbelts, too.</p>
+
+                    <p>The Street Survival school is an all day event, from 8:30am to approximately 3:30pm. Cost per student is $95, lunch on site is included.</p>
+
+                    <p class="text-center">
+                      <a class="btn btn-primary" href="http://streetsurvival.org/schools/frequently-asked-questions/">
+                        Street Survival FAQ <i class="fa fa-angle-double-right"></i>
+                      </a><!--TODO: registration link-->
+                      <a class="btn btn-primary" href="https://www.motorsportreg.com/index.cfm/event/register.trss/uidEvent/0C5F885C-ADF5-CAD5-43B5FE1B8AB6B7F0">
+                        Register! <i class="fa fa-angle-double-right"></i>
+                      </a>
+                    </p>
+                  </div>
+                </div>
+              </div>
             <h2 class="azbr-color"><em>Tucson Autocross</em></h2>
             <div class="well well-sm">
               <?php AutoxEvents::upcoming_block( $regApiIds['AZBR'], $regApiKeys['AZBR'] ); ?>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,29 @@
 ?>
         <div class="row">
           <div class="col-md-7">
+            <h2 class="azbr-color"><em>Fall into Awesome</em></h2>
+              <div class="well well-sm">
+                <div class="row">
+                  <div class="col-md-4 hidden-xs">
+                    <img class="img-responsive" src="<?php echo baseHref; ?>images/awesome/bill_murray.jpg"/>
+                  </div>
+                  <div  class="col-md-8">
+                    <p>
+                      AZBR is hosting another two day, tour-style autocross extravagana
+                      at the Marana Regional Airport <!--TODO: date--><strong>October 23rd and 24th</strong>. As with the previous
+                      Awesome Series we have run, you can sign up for just Saturday, just Sunday, or - if you're
+                      awesome enough - both days. Registering <em>and paying</em> for both days by the close of on site registration on Saturday will get you $10 off your autocross weekend.
+                      Online registration for both days opens on <!--TODO: date-->Thursday, October 14th at 7:00pm and closes on <!--TODO: date-->Thursday, October 21 at 7:00pm.
+                    </p>
+                    <p>
+                      <a class="btn btn-block btn-primary" href="<?php echo baseHref;?>autocross/awesome.html">
+                        All the Awesome Details
+                        <i class="fa fa-angle-double-right"></i>
+                      </a>
+                    </p>
+                  </div>
+                </div>
+              </div>
             <h2 class="azbr-color"><em>Tire Rack Street Survival - November 7th</em></h2>
             <div class="well well-sm">
               <p>


### PR DESCRIPTION
## Why are we doing this?

We need to add the details for the two days of awesome and the TRSS

## How can someone view these changes?

dev.azbrscca.org

Steps to manually verify the change:

Look at front page. Click all the 2DA and TRSS links. Make sure they go to reasonable places
On the autocross/awesome.html page, click all the links and make sure they go to the intended places
Inspect all added information for accuracy

## What possible risks or adverse effects are there?

Biggest risk is wrong information leading entrants astray

## What are the follow-up tasks?

After the event, the front page needs to be updated to remove the 2DA blurb.

## Are there any known issues?

NONE
