### PR TITLE
Paypal name field

### DIFF
--- a/autocross/paypal.html
+++ b/autocross/paypal.html
@@ -9,6 +9,7 @@
           <div class="col-md-12">
             <div class="well well-sm">
               <!-- Begin two days of awesome payment info -->
+              <!-- These are now considered the "old" buttons - dropdown menu for num of TOs, but no text box for driver name
               <h3 class="text-info text-center">Two Days of Awesome - SCCA Member</h3>
               <p>
                 Select one of these options if you are a full status SCCA member taking advantage of the $10 discount for pre-registering for both days.
@@ -37,30 +38,6 @@
                 </div>
               </div>
               <p/>
-<!--Old Marana buttons
-                <div class="col-md-4 col-xs-6">
-                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
-                  <input type="hidden" name="cmd" value="_s-xclick">
-                  <input type="hidden" name="hosted_button_id" value="XPXBJSCVJG7J2">
-                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-                  </form>
-                </div>
-              </div>
-              <p/>
-              <div class="row">
-                <div class="col-md-4 col-xs-6">
-                  Two Day Competition Entry Only - $42
-                </div>
-                <div class="col-md-4 col-xs-6">
-                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
-                  <input type="hidden" name="cmd" value="_s-xclick">
-                  <input type="hidden" name="hosted_button_id" value="W6EZ2EBECYGTU">
-                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-                  </form>
-                </div>
-              </div>-->
               <h3 class="text-info text-center">Two Days of Awesome - Non SCCA (Weekend) Member</h3>
               <p>
                 Select one of these options if you are taking advantage of the $10 discount for pre-registering for both days, but do not have a full time SCCA membership.
@@ -96,31 +73,121 @@
                   </form>
                 </div>
               </div>
-              <p/>
-                <!--Old marana buttons
+              <p/>-->
+              <h3 class="text-info text-center">Two Days of Awesome - SCCA Member</h3>
+              <p>
+                Select one of these options if you are a full status SCCA member taking advantage of the $10 discount for pre-registering for both days.
+              </p>
+              <div class="row">
+                <div class="col-md-4 col-xs-6">
+                  Two Day Competition Entry Only: $50
+                </div>
                 <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick">
-                  <input type="hidden" name="hosted_button_id" value="JS4HT2TZP8MT6">
+                  <input type="hidden" name="hosted_button_id" value="W6EZ2EBECYGTU">
+                  <table>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  </table>
+                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                  </form>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-4 col-xs-6">
+                  Two Day Competition + 1 Day Time Only: $60
+                </div>
+                <div class="col-md-4 col-xs-6">
+                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                  <input type="hidden" name="cmd" value="_s-xclick">
+                  <input type="hidden" name="hosted_button_id" value="8B8D7HJYLWCHL">
+                  <table>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  </table>
+                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                  </form>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-4 col-xs-6">
+                  Two Day Competition + 2 Day Time Only $70
+                </div>
+                <div class="col-md-4 col-xs-6">
+                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                  <input type="hidden" name="cmd" value="_s-xclick">
+                  <input type="hidden" name="hosted_button_id" value="XPXBJSCVJG7J2">
+                  <table>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  </table>
                   <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
                   <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
                   </form>
                 </div>
               </div>
               <p/>
+              <h3 class="text-info text-center">Two Days of Awesome - Non SCCA (Weekend) Member</h3>
+              <p>
+                Select one of these options if you are taking advantage of the $10 discount for pre-registering for both days, but do not have a full time SCCA membership.
+              </p>
+              <div class="alert alert-warning">
+                <p>
+                  The SCCA requires that all event participants be SCCA members.
+                  If you are not an SCCA member a weekend membership is available for an extra $10,
+                  which is included in the Non SCCA entry fees shown below. For the Two Days of
+                  Awesome, this is a single $10 charge that covers both days.
+                </p>
+              </div>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  Two Day Competition Entry Only - $52
+                  2 Day Competition Only: $60
                 </div>
                 <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick">
                   <input type="hidden" name="hosted_button_id" value="AXRBR3TQJ623S">
+                  <table>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  </table>
                   <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
                   <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
                   </form>
                 </div>
               </div>
+              <div class="row">
+                <div class="col-md-4 col-xs-6">
+                  2 Day Competition + 1 Day Time Only: $70
+                </div>
+                <div class="col-md-4 col-xs-6">
+                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                  <input type="hidden" name="cmd" value="_s-xclick">
+                  <input type="hidden" name="hosted_button_id" value="3BH6QQLRN5XVC">
+                  <table>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  </table>
+                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                  </form>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-4 col-xs-6">
+                  2 Day Competition + 2 Day Time Only: $80
+                </div>
+                <div class="col-md-4 col-xs-6">
+                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                  <input type="hidden" name="cmd" value="_s-xclick">
+                  <input type="hidden" name="hosted_button_id" value="JS4HT2TZP8MT6">
+                  <table>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  </table>
+                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                  </form>
+                </div>
+              </div>
+              <p/>
               <!-- End two days of awesome payment info -->
               
               <!-- Begin single entry payment info -->
@@ -136,6 +203,9 @@
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick">
                   <input type="hidden" name="hosted_button_id" value="9JCHFM4ZXT6AG">
+                  <table>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  </table>
                   <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
                   <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
                   </form>
@@ -150,6 +220,9 @@
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick">
                   <input type="hidden" name="hosted_button_id" value="EASWPKGAUB6HY">
+                  <table>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  </table>
                   <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
                   <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
                   </form>
@@ -174,6 +247,9 @@
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick">
                   <input type="hidden" name="hosted_button_id" value="MCT4HMFYRQYNE">
+                  <table>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  </table>
                   <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
                   <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
                   </form>
@@ -226,7 +302,38 @@
                   </form>
                 </div>
               </div>
+              <h3 class="text-info text-center">Time Only</h3>
+              <p>
+                Select this if you already paid for a competition-only entry, but have since edited your registration to include time only runs and need to pay the difference,
+              </p>
+              <div class="row">
+                <div class="col-md-4 col-xs-6">
+                  1 Day Time Only: $10
+                </div>
+                <div class="col-md-4 col-xs-6">
+                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                  <input type="hidden" name="cmd" value="_s-xclick">
+                  <input type="hidden" name="hosted_button_id" value="Y4ESQPJMSNR92">
+                  <table>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  </table>
+                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                  </form>
+                </div>
+              </div>
               <!-- End single entry payment info -->
+<!--Two day time only
+<form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+<input type="hidden" name="cmd" value="_s-xclick">
+<input type="hidden" name="hosted_button_id" value="JKUKCGRBFC73E">
+<table>
+<tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+</table>
+<input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+<img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+</form>
+-->
               
             </div>
           </div>

--- a/autocross/paypal.html
+++ b/autocross/paypal.html
@@ -74,7 +74,7 @@
                 </div>
               </div>
               <p/>-->
-              <h3 class="text-info text-center">Two Days of Awesome - SCCA Member</h3>
+              <h3 class="text-info">Two Days of Awesome - SCCA Member</h3>
               <p>
                 Select one of these options if you are a full status SCCA member taking advantage of the $10 discount for pre-registering for both days.
               </p>
@@ -127,7 +127,7 @@
                 </div>
               </div>
               <p/>
-              <h3 class="text-info text-center">Two Days of Awesome - Non SCCA (Weekend) Member</h3>
+              <h3 class="text-info">Two Days of Awesome - Non SCCA (Weekend) Member</h3>
               <p>
                 Select one of these options if you are taking advantage of the $10 discount for pre-registering for both days, but do not have a full time SCCA membership.
               </p>
@@ -191,7 +191,7 @@
               <!-- End two days of awesome payment info -->
               
               <!-- Begin single entry payment info -->
-              <h3 class="text-info text-center">Single Day Entry - SCCA Member</h3>
+              <h3 class="text-info">Single Day Entry - SCCA Member</h3>
               <p>
                 Select one of these options if you are a full status SCCA member.
               </p>
@@ -228,7 +228,7 @@
                   </form>
                 </div>
               </div>
-              <h3 class="text-info text-center">Single Day Entry - Non SCCA (Weekend) Member</h3>
+              <h3 class="text-info">Single Day Entry - Non SCCA (Weekend) Member</h3>
               <p>
                 Select one of these options if you do not have a full time SCCA membership.
               </p>

--- a/autocross/paypal.html
+++ b/autocross/paypal.html
@@ -188,6 +188,9 @@
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick">
                   <input type="hidden" name="hosted_button_id" value="VYQZ5UML7B3ZE">
+                  <table>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  </table>
                   <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
                   <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
                   </form>

--- a/autocross/paypal.html
+++ b/autocross/paypal.html
@@ -80,7 +80,7 @@
               </p>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  Two Day Competition Entry Only: $50
+                  &nbsp;<br/>Two Day Competition Entry Only: $50
                 </div>
                 <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
@@ -96,7 +96,7 @@
               </div>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  Two Day Competition + 1 Day Time Only: $60
+                  &nbsp;<br/>Two Day Competition + 1 Day Time Only: $60
                 </div>
                 <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
@@ -112,7 +112,7 @@
               </div>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  Two Day Competition + 2 Day Time Only $70
+                  &nbsp;<br/>Two Day Competition + 2 Day Time Only $70
                 </div>
                 <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
@@ -141,7 +141,7 @@
               </div>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  2 Day Competition Only: $60
+                  &nbsp;<br/>2 Day Competition Only: $60
                 </div>
                 <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
@@ -157,7 +157,7 @@
               </div>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  2 Day Competition + 1 Day Time Only: $70
+                  &nbsp;<br/>2 Day Competition + 1 Day Time Only: $70
                 </div>
                 <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
@@ -173,7 +173,7 @@
               </div>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  2 Day Competition + 2 Day Time Only: $80
+                  &nbsp;<br/>2 Day Competition + 2 Day Time Only: $80
                 </div>
                 <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
@@ -197,7 +197,7 @@
               </p>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  Single Day Competition Entry Only - $30
+                  &nbsp;<br/>Single Day Competition Entry Only - $30
                 </div>
                 <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
@@ -214,7 +214,7 @@
               <p/>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  Single Day Competition + Time Only - $40
+                  &nbsp;<br/>Single Day Competition + Time Only - $40
                 </div>
                 <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
@@ -241,7 +241,7 @@
               </div>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  Single Day Competition Entry Only - $40
+                  &nbsp;<br/>Single Day Competition Entry Only - $40
                 </div>
                 <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
@@ -258,7 +258,7 @@
               <p/>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  Single Day Competition + Time Only - $50
+                  &nbsp;<br/>Single Day Competition + Time Only - $50
                 </div>
                 <div class="col-md-4 col-xs-6">
                   <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">


### PR DESCRIPTION
## Why are we doing this?

We're adding the "driver name" text field to all paypal buttons, to better track the name for each driver that's getting paid for. Also, we've updated the two days of awesome payment options to account for this.

## How can someone view these changes?

dev.azbrscca.org

Steps to manually verify the change:

Go to https://dev.azbrscca.org/autocross/paypal.html in a private browser
Fill in a driver name for a button and click Add to Cart
Make sure you go to paypal and the cart shows the correct payment amount for the button you clicked

## What possible risks or adverse effects are there?

If buttons prices are inaccurate, people may under/over pay us.

## What are the follow-up tasks?

Registration site needs to be appropriately updated as well.

## Are there any known issues?

The UI/UX is crummy but I hope I can rig the reg site to better handle two-day event payments.
