### PR TITLE
Update summer schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,24 +9,6 @@
 ?>
         <div class="row">
           <div class="col-md-7">
-              <h2 class="azbr-color">Road Rally</h2>
-        <div class="row">
-          <div class="col-md-8">
-            <div class="well well-sm text-center">
-              <img class="img-responsive" src="<?php echo baseHref; ?>images/desert-sands-2017.jpg" />
-            </div>
-          </div>
-          <div class="col-md-4">
-            <div class="well well-sm text-center">
-              <h4 class="text-center">Details for March 4 &amp; 5</h4>
-              Entry fees are $60 per car per rally, for SCCA members. For non-SCCA members, entry fees are $70 per car, per rally.<br/>
-              Mailing address and additional payment information are available on the event entry form.<br/>
-              <a class="btn btn-md btn-primary" href="<?php echo baseHref; ?>documents/forms/regional_rally_entry_form.pdf">
-                Download Event Entry Form
-              </a>
-            </div>
-          </div>
-        </div>
   
             <h2 class="azbr-color"><em>Tucson Autocross</em></h2>
             <div class="well well-sm">


### PR DESCRIPTION
## Why are we doing this?

This is the new later start summer schedule for Musselman events

## How can someone view these changes?

dev.azbrscca.org

Steps to manually verify the change:

Point dev site at branch
Navigate to Autocross -> event calendar
Verify times for May event match expectation
Verify "Summer" times on right side column match expectation

## What possible risks or adverse effects are there?

If times are wrong, people will show up at the gates at the wrong time - too early or too late.

## What are the follow-up tasks?

None

## Are there any known issues?

none