### PR TITLE
Kino changes

### DIFF
--- a/about/board.html
+++ b/about/board.html
@@ -55,7 +55,7 @@
           <div class="col-md-3">
             <div class="alert alert-info">
               <strong>Rallycross Director</strong><br/>
-              Lee Shadbolt</br>
+              Justin McBee</br>
               rallycrossdirector -at- azbrscca.org<br/>
             </div>
           </div>

--- a/autocross/calendar.html
+++ b/autocross/calendar.html
@@ -39,32 +39,31 @@
     )
 */
     // Kino times
-    // TODO: fix the tech open/close?
     "spring" => array(
       "site_open" => "7:30am",
-      "reg_tech_open" => "7:45am",
-      "reg_close" => "9:30am",
-      "tech_close" => "9:45am",
-      "novice_walk" => "9:45am",
-      "site_meeting" => "10:00am"
+      "reg_tech_open" => "7:30am",
+      "reg_close" => "8:30am",
+      "tech_close" => "8:45am",
+      "novice_walk" => "9:00am",
+      "site_meeting" => "9:15am"
     ),
 
     "summer" => array(
       "site_open" => "6:30am",
-      "reg_tech_open" => "7:30am",
-      "reg_close" => "9:00am",
-      "tech_close" => "9:15am",
-      "novice_walk" => "9:15am",
-      "site_meeting" => "9:30am"
+      "reg_tech_open" => "6:30am",
+      "reg_close" => "7:30am",
+      "tech_close" => "7:45am",
+      "novice_walk" => "8:00am",
+      "site_meeting" => "8:15am"
     ),
 
     "fall" => array(
       "site_open" => "7:30am",
-      "reg_tech_open" => "7:45am",
-      "reg_close" => "9:30am",
-      "tech_close" => "9:45am",
-      "novice_walk" => "9:45am",
-      "site_meeting" => "10:00am"
+      "reg_tech_open" => "7:30am",
+      "reg_close" => "8:30am",
+      "tech_close" => "8:45am",
+      "novice_walk" => "9:00am",
+      "site_meeting" => "9:15am"
     )
   );
 

--- a/autocross/calendar.html
+++ b/autocross/calendar.html
@@ -8,8 +8,9 @@
   $json_string = RegAPI::getRequest( "events/calendar/".$calendar_year."/", $regApiIds['AZBR'], $regApiKeys['AZBR'], array( 'public' => 1 ));
   $events = json_decode( $json_string, true );
 
+  // TODO: we should add additional site-specific schedules (e.g. spring_kino, summer_kino, etc.).
   $schedules = array(
-
+/* Musselman times
     "spring" => array(
       "site_open" => "8:30am",
       "reg_tech_open" => "8:45am",
@@ -36,18 +37,53 @@
       "novice_walk" => "9:45am",
       "site_meeting" => "10:00am"
     )
+*/
+    // Kino times
+    // TODO: fix the tech open/close?
+    "spring" => array(
+      "site_open" => "7:30am",
+      "reg_tech_open" => "7:45am",
+      "reg_close" => "9:30am",
+      "tech_close" => "9:45am",
+      "novice_walk" => "9:45am",
+      "site_meeting" => "10:00am"
+    ),
+
+    "summer" => array(
+      "site_open" => "6:30am",
+      "reg_tech_open" => "7:30am",
+      "reg_close" => "9:00am",
+      "tech_close" => "9:15am",
+      "novice_walk" => "9:15am",
+      "site_meeting" => "9:30am"
+    ),
+
+    "fall" => array(
+      "site_open" => "7:30am",
+      "reg_tech_open" => "7:45am",
+      "reg_close" => "9:30am",
+      "tech_close" => "9:45am",
+      "novice_walk" => "9:45am",
+      "site_meeting" => "10:00am"
+    )
   );
 
+  // TODO: site-specific run work, mostly for Musselman style (comp/TO combined). What follows below is hacky and dumb.
   $run_work = array(
     //Musselman run work
-    "spring" => array( "A" => "C", "C" => "A" ),
-    "summer" => array( "A" => "C", "C" => "A" ),
-    "fall" => array( "A" => "C", "C" => "A" ),
+    //"spring" => array( "A" => "C", "C" => "A" ),
+    //"summer" => array( "A" => "C", "C" => "A" ),
+    //"fall" => array( "A" => "C", "C" => "A" ),
     
     //Non-Musselman run work
     //"spring" => array( "A" => "C", "B" => "D", "C" => "A", "D" => "B" ),
     //"summer" => array( "A" => "B", "B" => "A", "C" => "D", "D" => "C" ),
     //"fall" => array( "A" => "C", "B" => "D", "C" => "A", "D" => "B" ),
+    
+    //Kino run work
+    "spring" => array( "A" => "B", "B" => "A", "C" => "D", "D" => "C" ),
+    "summer" => array( "A" => "B", "B" => "A", "C" => "D", "D" => "C" ),
+    "fall" => array( "A" => "B", "B" => "A", "C" => "D", "D" => "C" ),
 
   );
 
@@ -214,6 +250,7 @@
 
           <div class="col-md-4">
 
+            <!-- TODO: this needs rework or elimination, if we want to move to site-specific schedules. -->
             <div class="well well-sm">
               <h4 class="text-center">Schedule &amp; Run/Work Order</h4>
 

--- a/autocross/calendar.html
+++ b/autocross/calendar.html
@@ -181,6 +181,7 @@
 
     // show the event schedule when registration is open
     // and after it is closed until the day after the event
+    // TODO: also show the schedule maybe 7-14 days before reg opens
     $past = $event[ 'date_ts' ] + 24*60*60 < time();
     $show_schedule =
       (($event[ 'status' ] == "open" ) || ($event[ 'status' ] == "closed")) && !$past;

--- a/autocross/details.html
+++ b/autocross/details.html
@@ -28,8 +28,9 @@
                   More Details <i class="fa fa-angle-double-right"></i>
                 </a>
               </p>
+              <p/>
               <hr/>
-              
+              <p/>
               <h3 class="text-info text-center">Event Site: Musselman Honda Circuit</h3>
               <p class="text-center">
                 <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d17069.634903728867!2d-110.7949208!3d32.0362718!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x21059f3431d2433a!2sMusselman%20Honda%20Circuit!5e1!3m2!1sen!2sus!4v1598927664014!5m2!1sen!2sus" width="600" height="450" frameborder="0" style="border:0;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>

--- a/autocross/details.html
+++ b/autocross/details.html
@@ -28,9 +28,11 @@
                   More Details <i class="fa fa-angle-double-right"></i>
                 </a>
               </p>
-              <p/>
+              <br/>
+              <br/>
               <hr/>
-              <p/>
+              <br/>
+              <br/>
               <h3 class="text-info text-center">Event Site: Musselman Honda Circuit</h3>
               <p class="text-center">
                 <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d17069.634903728867!2d-110.7949208!3d32.0362718!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x21059f3431d2433a!2sMusselman%20Honda%20Circuit!5e1!3m2!1sen!2sus!4v1598927664014!5m2!1sen!2sus" width="600" height="450" frameborder="0" style="border:0;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>

--- a/autocross/details.html
+++ b/autocross/details.html
@@ -14,18 +14,17 @@
                 AZ Border Region hosts autocross events at the following sites.
               </p>
               
-              <h3 class="text-info text-center">Event Site: Marana Regional Airport</h3>
+              <h3 class="text-info text-center">Event Site: Kino Sports Complex</h3>
               <p class="text-center">
-                Marana Regional Airport is located at 11700 W Avra Valley Rd,
-                approximately 5 miles off I-10. Whether coming from Phoenix or Tucson,
-                the easiest way to access the site is to use Exit 242 from I-10 for
-                Avra Valley Rd, and then proceed to the West.
+                <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d5681.4489861351985!2d-110.935138396096!3d32.17487285238628!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x86d67a9a23b55817%3A0xfc3290a00462e81a!2sKino%20Sports%20Complex!5e1!3m2!1sen!2sus!4v1665955657267!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
               </p>
               <p class="text-center">
-                <iframe width="600" height="400" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://www.google.com/maps?f=q&amp;source=s_q&amp;hl=en&amp;geocode=&amp;q=Marana+Regional+Airport&amp;sll=32.471105,-111.251046&amp;sspn=0.26416,0.441513&amp;ie=UTF8&amp;hq=&amp;hnear=Avra+Valley+Airport,+Marana,+Pima,+Arizona+85653&amp;t=h&amp;ll=32.410255,-111.218548&amp;spn=0.032173,0.054674&amp;z=14&amp;iwloc=A&amp;output=embed"></iframe>
+                Kino Sports Complex is located at 2500 E Ajo Way, Tucson AZ, right next
+                to the intersection of I-10 and Kino Parkway. Please click the More Details
+                button below for specific driving direction to the lot(s) we are using.
               </p>
               <p class="text-center">
-                <a class="btn btn-block btn-md btn-primary" href="<?php echo baseHref; ?>autocross/marana.html">
+                <a class="btn btn-block btn-md btn-primary" href="<?php echo baseHref; ?>autocross/kino.html">
                   More Details <i class="fa fa-angle-double-right"></i>
                 </a>
               </p>
@@ -33,12 +32,12 @@
               
               <h3 class="text-info text-center">Event Site: Musselman Honda Circuit</h3>
               <p class="text-center">
+                <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d17069.634903728867!2d-110.7949208!3d32.0362718!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x21059f3431d2433a!2sMusselman%20Honda%20Circuit!5e1!3m2!1sen!2sus!4v1598927664014!5m2!1sen!2sus" width="600" height="450" frameborder="0" style="border:0;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
+              </p>
+              <p class="text-center">
                 Musselman Honda Circuit is located at 11800 S Harrison Rd,
                 Tucson AZ, approximately 4 miles off I-10. Coming from Tucson, take
                 I-10 East and use Exit 273 for Rita Rd, and then proceed to the South.
-              </p>
-              <p class="text-center">
-                <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d17069.634903728867!2d-110.7949208!3d32.0362718!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x21059f3431d2433a!2sMusselman%20Honda%20Circuit!5e1!3m2!1sen!2sus!4v1598927664014!5m2!1sen!2sus" width="600" height="450" frameborder="0" style="border:0;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
               </p>
               <p class="text-center">
                 <a class="btn btn-block btn-md btn-primary" href="<?php echo baseHref; ?>autocross/musselman.html">

--- a/autocross/kino.html
+++ b/autocross/kino.html
@@ -1,0 +1,166 @@
+<?php
+  require_once "../common/Common.php";
+
+  Display::open_page();
+?>
+
+        <h2 class="azbr-color">Autocross Site &amp; Entry Fee Information</h2>
+
+        <div class="row">
+
+          <div class="col-md-8">
+            <div class="well well-sm">
+              <h3 class="text-info text-center">Event Site: Marana Regional Airport</h3>
+
+              <p class="text-center">
+                Marana Regional Airport is located at 11700 W Avra Valley Rd,
+                approximately 5 miles off I-10. Whether coming from Phoenix or Tucson,
+                the easiest way to access the site is to use Exit 242 from I-10 for
+                Avra Valley Rd, and then proceed to the West.
+              </p>
+
+              <p class="text-center">
+                <iframe width="600" height="400" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://www.google.com/maps?f=q&amp;source=s_q&amp;hl=en&amp;geocode=&amp;q=Marana+Regional+Airport&amp;sll=32.471105,-111.251046&amp;sspn=0.26416,0.441513&amp;ie=UTF8&amp;hq=&amp;hnear=Avra+Valley+Airport,+Marana,+Pima,+Arizona+85653&amp;t=h&amp;ll=32.410255,-111.218548&amp;spn=0.032173,0.054674&amp;z=14&amp;iwloc=A&amp;output=embed"></iframe>
+              </p>
+
+              <hr/>
+
+              <!--This used to be the primary gate. We've stopped using it entirely so we're removing from the page to avoid confusion, but saving it in case we need to bring it back.
+              <h4 class="text-info text-center">Alternate Access Gate (South Paddock Configuration)</h4>
+              
+              <p>
+                The alternate gate is used to access the site when paddock is configured to be at the
+                South end of the site. Travelling West on
+                Avra Valley Rd from I-10, you will cross a canal with 100ft long concrete walls on both 
+                sides of the road. After a quarter mile, you will see an opening in the fence on your
+                right to a gravel road with cones marking the entrance. Follow this road to a gravel
+                parking lot where you will find the entrance gate and waiver station.
+              </p>
+              <p>
+                Click the image for a full resolution version.
+              </p>
+              
+              <a href="<?php echo baseHref; ?>images/autocross/primary_site_entrance.png">
+              <img class="img-responsive" src="<?php echo baseHref; ?>images/autocross/primary_site_entrance.png" />
+              </a>
+
+              <hr/>
+-->
+              <h4 class="text-info text-center">Primary Access Gate</h4>
+              
+              <p>
+                The primary gate is used to access the site for most regional events.
+                Travelling West on Avra Valley Rd from I-10, you will cross a canal with 100ft long concrete walls on both 
+                sides of the road. 400 feet past the canal, you will turn right onto a paved road.
+                Follow the paved road all the way around to the North end of the 
+                site, where you will find the entrance gate and waiver station.
+              </p>
+              <p>
+                Click the image for a full resolution version.
+              </p>
+              
+              <!--Yes, this is still "alternate_site_entrance.png" but this is now the primary entrance.-->
+              <a href="<?php echo baseHref; ?>images/autocross/alternate_site_entrance.png">              
+              <img class="img-responsive" src="<?php echo baseHref; ?>images/autocross/alternate_site_entrance.png" />
+              </a>
+
+              <hr/>
+
+              <h4 class="text-info text-center">Site Regulations</h4>
+
+              <div class="alert alert-danger text-center">
+                <i class="fa fa-exclamation-triangle fa-lg"></i>
+                <strong>
+                  This site is an active airport.<br/>
+                  Failure to comply with site regulations can result in you
+                  being asked to leave the event without a refund.
+                </strong>
+              </div>
+
+              <p>
+                Take extra precautions to ensure the site is kept safe, clean and not damaged in any way.
+                We need to build a positive relationship with the airport so we can continue use of the site.
+                Remind others around you if they appear to have forgotten the rules. There will be a number
+                of garbage cans located near the paddock, grid, and trailer. Please use them. AZBR will provide
+                12"x12" boards for use with jacks and jack stands. They must be used to prevent damage to the
+                pavement.
+              </p>
+              <ol>
+                <li>
+                  Site entry for participants is <a href="<?php echo baseHref; ?>autoross/calendar.php">listed
+                  on the event calendar for each event</a>. If you show up before the listed time please wait
+                  outside the black fence as we will be setting up the paddock and other required boundaries.
+                </li>
+                <li>
+                  Participating cars and tow vehicles shall be parked in the paddock area as indicated on the
+                  course/site map. Park on the pavement only. Do not park on the dirt.
+                </li>
+                <li>
+                  At each event, a mandatory drivers meeting will be held at the time
+                  <a href="<?php echo baseHref;?>events/calendar.php">indicated on the event calendar</a>.
+                  If more time is needed for setup/course walking we can move this out as required.
+                </li>
+                <li>
+                  The Beech Starship aircraft located on the site are off limits. Do not visit them.
+                </li>
+                <li>
+                  All participants and spectators shall remain in the autocross site area. This is
+                  defined by the lighter pavement area (uncoated) and can be seen on the overview map
+                  as the largest yellow rectangle. The aircraft taxi ways on the west and north edges are
+                  off limits. They are coated and appear darker.
+                </li>
+                <li>
+                  Boards shall be used under jacks and jack stands to prevent damage to the pavement.
+                  AZBR will provide the boards and they will be located near the paddock area. Ask if
+                  you cannot find them. Please return them when finished so they can be used at future events.
+                </li>
+                <li>
+                  Fluids leaked onto the pavement will NOT be tolerated. Water (i.e. air conditioner condensation)
+                  is acceptable. If your car leaks any oil or other fluids you will not be allowed to run. Either
+                  fix the leak before the event or do not participate. You can get a refund if desired up to 24
+                  hours before the event. If your car leaks when you show up on the site you will not be allowed
+                  to run. The exception to this is a breakage that occurs while participating in the event. If
+                  the leak can be repaired quickly off the pavement then continuing to run may be allowed. We
+                  do understand that things can go wrong while running your car.
+                </li>
+                <li>
+                  No filling of fluids-including but not limited to fuel, oil, and coolant-on any asphalt
+                  surface. As with the previous item, this is to prevent damage to the pavement. It is
+                  absolutely imperative that we do our best to maintain the surface if we are going to
+                  continue to enjoy the privilege of using it.
+                </li>
+                <li>
+                  Cars entered for competition shall remain on the paved area once entered until ready to
+                  leave the site. This is to minimize dirt and debris that could be transferred from unpaved
+                  areas by sticky tires.
+                </li>
+                <li>
+                  If your car is really loud, i.e. does not fit within the SCCA rules of 100db,
+                  then put a muffler on. If you have to question whether your car loudness is close
+                  to the limit, then put the muffler on.
+                </li>
+                <li>One (1) portable toilet will be provided (rented by AZBR). Please keep it clean.</li>
+                <li>
+                  The site is an active airport and any FOD (Foreign Object Debris), from a Kleenex to a
+                  water bottle, is extremely dangerous to the operating aircraft and to our future use
+                  of the site. Contain your own trash and pick up anything you see. There will be a few
+                  garbage cans on site. Use those or take trash off site when you leave.
+                </li>
+                <li>
+                  If an aircraft taxis on the either of the two taxi ways immediately adjacent to the course,
+                  the event will be stopped until the aircraft is clear of the area. If you are in the middle
+                  of a run you will get a re-run. This is not a likely scenario, but be prepared in case it
+                  happens.
+                </li>
+              </ol>
+            </div>
+          </div>
+
+<?php
+  Display::print_autox_entry_fees();
+?>
+        </div>
+
+<?php
+  Display::close_page();
+?>

--- a/autocross/kino.html
+++ b/autocross/kino.html
@@ -35,10 +35,14 @@
                 </div>
               </div>
               <p>
-                Travel East on Ajo Way for about half a mile. At the traffic light, turn right on Forgeus Ave. Drive for about
-                a quarter of a mile, then turn left onto District St. Take the next right turn, then drive another quarter of a
-                mile to the stop sign at the intersection with Milber. After stopping, drive straight ahead across Milber into
-                the parking lot and check in at the waiver station.
+                <h5 class="alert alert-warning text-center">
+                  Please enter the site using the intersection of Country Club and Milber. Detailed directions are below.
+                </h5>
+              </p>
+              <p>
+                Travel East on Ajo Way for about a mile, until you reach the traffic light at Country Club Road. Turn right
+                and drive about half a mile, then turn right onto Milber Street. The waiver station is at the entrance to
+                paddock, which is on the left about a quarter mile down the street.
               </p>
 
               <hr/>

--- a/autocross/kino.html
+++ b/autocross/kino.html
@@ -89,6 +89,11 @@
                   are 25MPH or lower. Once in paddock, the speed limit is 10MPH.
                 </li>
                 <li>
+                  Boards shall be used under jacks and jack stands to prevent damage to the pavement.
+                  AZBR will provide the boards and they will be located near the paddock area. Ask if
+                  you cannot find them. Please return them when finished so they can be used at future events.
+                </li>
+                <li>
                   All participants and spectators shall remain in the autocross site area (paddock and course), as this
                   is the only part of the sports complex we have rented. If you see a closed gate anywhere, do not attempt
                   to open it.
@@ -106,11 +111,6 @@
                   At each event, an event meeting (mandatory for all drivers and spectators) will be held at the time
                   <a href="<?php echo baseHref;?>events/calendar.php">indicated on the event calendar</a>.
                   If more time is needed for setup/course walking we can move this out as required.
-                </li>
-                <li>
-                  Boards shall be used under jacks and jack stands to prevent damage to the pavement.
-                  AZBR will provide the boards and they will be located near the paddock area. Ask if
-                  you cannot find them. Please return them when finished so they can be used at future events.
                 </li>
                 <li>
                   Fluids leaked onto the pavement will NOT be tolerated. Water (i.e. air conditioner condensation)

--- a/autocross/kino.html
+++ b/autocross/kino.html
@@ -85,7 +85,7 @@
                   unfortunately emotional support animals do not qualify for this.
                 </li>
                 <li>
-                  Strictly follow all posted speed limits. Forgeus Ave and other streets internal to the complex
+                  Strictly follow all posted speed limits. Milber St and other streets internal to the complex
                   are 25MPH or lower. Once in paddock, the speed limit is 10MPH.
                 </li>
                 <li>

--- a/autocross/kino.html
+++ b/autocross/kino.html
@@ -35,14 +35,15 @@
                 </div>
               </div>
               <p>
-                <h5 class="alert alert-warning text-center">
-                  Please enter the site using the intersection of Country Club and Milber. Detailed directions are below.
-                </h5>
-              </p>
-              <p>
                 Travel East on Ajo Way for about a mile, until you reach the traffic light at Country Club Road. Turn right
                 and drive about half a mile, then turn right onto Milber Street. The waiver station is at the entrance to
                 paddock, which is on the left about a quarter mile down the street.
+              </p>
+              <p>
+                <h5 class="alert alert-warning text-center">
+                  Please adhere to the above routing and only enter/exit the site from the intersection of Country Club and Milber. This keeps our
+                  traffic away from the emergency room entrance of the nearby hospital.
+                </h5>
               </p>
 
               <hr/>
@@ -137,7 +138,7 @@
                   to the limit, then put the muffler on.
                 </li>
                 <li>
-                  TODO: restrooms?
+                  One (1) portable toilet will be provided (rented by AZBR). Please keep it clean.
                 </li>
                 <li>
                   Any loose trash left after the event is extremely dangerous to our future use

--- a/autocross/kino.html
+++ b/autocross/kino.html
@@ -10,42 +10,33 @@
 
           <div class="col-md-8">
             <div class="well well-sm">
-              <h3 class="text-info text-center">Event Site: Marana Regional Airport</h3>
+              <h3 class="text-info text-center">Event Site: Kino Sports Complex</h3>
 
               <p class="text-center">
-                Marana Regional Airport is located at 11700 W Avra Valley Rd,
-                approximately 5 miles off I-10. Whether coming from Phoenix or Tucson,
-                the easiest way to access the site is to use Exit 242 from I-10 for
-                Avra Valley Rd, and then proceed to the West.
+                Kino Sports Complex is located at 2500 E Ajo Way, Tucson AZ, right next
+                to the intersection of I-10 and Kino Parkway.
               </p>
-
+              <div class="row">
+                <div class="col-md-6">
+                  <p>
+                    Coming from the northwest, take I-10 East to exit 263B, "Kino Pkwy N." After exiting the freeway,
+                    take the next right turn, following the sign to "Phoenix / Ajo Way." At the next traffic light,
+                    turn left to go East on Ajo Way.
+                  </p>
+                </div>
+                <div class="col-md-6">
+                  <p>
+                    Coming from the southeast, take I-10 West to exit 263, "Ajo Way / Kino Pkwy." At the traffic light,
+                    turn right to go East on Ajo Way.
+                  </p>
+                </div>
+              </div>
               <p class="text-center">
-                <iframe width="600" height="400" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://www.google.com/maps?f=q&amp;source=s_q&amp;hl=en&amp;geocode=&amp;q=Marana+Regional+Airport&amp;sll=32.471105,-111.251046&amp;sspn=0.26416,0.441513&amp;ie=UTF8&amp;hq=&amp;hnear=Avra+Valley+Airport,+Marana,+Pima,+Arizona+85653&amp;t=h&amp;ll=32.410255,-111.218548&amp;spn=0.032173,0.054674&amp;z=14&amp;iwloc=A&amp;output=embed"></iframe>
+                <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d5681.4489861351985!2d-110.935138396096!3d32.17487285238628!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x86d67a9a23b55817%3A0xfc3290a00462e81a!2sKino%20Sports%20Complex!5e1!3m2!1sen!2sus!4v1665955657267!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
               </p>
 
               <hr/>
 
-              <!--This used to be the primary gate. We've stopped using it entirely so we're removing from the page to avoid confusion, but saving it in case we need to bring it back.
-              <h4 class="text-info text-center">Alternate Access Gate (South Paddock Configuration)</h4>
-              
-              <p>
-                The alternate gate is used to access the site when paddock is configured to be at the
-                South end of the site. Travelling West on
-                Avra Valley Rd from I-10, you will cross a canal with 100ft long concrete walls on both 
-                sides of the road. After a quarter mile, you will see an opening in the fence on your
-                right to a gravel road with cones marking the entrance. Follow this road to a gravel
-                parking lot where you will find the entrance gate and waiver station.
-              </p>
-              <p>
-                Click the image for a full resolution version.
-              </p>
-              
-              <a href="<?php echo baseHref; ?>images/autocross/primary_site_entrance.png">
-              <img class="img-responsive" src="<?php echo baseHref; ?>images/autocross/primary_site_entrance.png" />
-              </a>
-
-              <hr/>
--->
               <h4 class="text-info text-center">Primary Access Gate</h4>
               
               <p>

--- a/autocross/kino.html
+++ b/autocross/kino.html
@@ -16,6 +16,9 @@
                 Kino Sports Complex is located at 2500 E Ajo Way, Tucson AZ, right next
                 to the intersection of I-10 and Kino Parkway.
               </p>
+              <p class="text-center">
+                <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d5681.4489861351985!2d-110.935138396096!3d32.17487285238628!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x86d67a9a23b55817%3A0xfc3290a00462e81a!2sKino%20Sports%20Complex!5e1!3m2!1sen!2sus!4v1665955657267!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+              </p>
               <div class="row">
                 <div class="col-md-6">
                   <p>
@@ -31,28 +34,21 @@
                   </p>
                 </div>
               </div>
-              <p class="text-center">
-                <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d5681.4489861351985!2d-110.935138396096!3d32.17487285238628!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x86d67a9a23b55817%3A0xfc3290a00462e81a!2sKino%20Sports%20Complex!5e1!3m2!1sen!2sus!4v1665955657267!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+              <p>
+                Travel East on Ajo Way for about half a mile. At the traffic light, turn right on Forgeus Ave. Drive for about
+                a quarter of a mile, then turn left onto District St. Take the next right turn, then drive another quarter of a
+                mile to the stop sign at the intersection with Milber. After stopping, drive straight ahead across Milber into
+                the parking lot and check in at the waiver station.
               </p>
 
               <hr/>
 
-              <h4 class="text-info text-center">Primary Access Gate</h4>
-              
               <p>
-                The primary gate is used to access the site for most regional events.
-                Travelling West on Avra Valley Rd from I-10, you will cross a canal with 100ft long concrete walls on both 
-                sides of the road. 400 feet past the canal, you will turn right onto a paved road.
-                Follow the paved road all the way around to the North end of the 
-                site, where you will find the entrance gate and waiver station.
-              </p>
-              <p>
-                Click the image for a full resolution version.
+                The image below is the site layout. Click the image for a full resolution version.
               </p>
               
-              <!--Yes, this is still "alternate_site_entrance.png" but this is now the primary entrance.-->
-              <a href="<?php echo baseHref; ?>images/autocross/alternate_site_entrance.png">              
-              <img class="img-responsive" src="<?php echo baseHref; ?>images/autocross/alternate_site_entrance.png" />
+              <a href="<?php echo baseHref; ?>images/autocross/kino01.png">              
+              <img class="img-responsive" src="<?php echo baseHref; ?>images/autocross/kino01.png" />
               </a>
 
               <hr/>
@@ -62,7 +58,6 @@
               <div class="alert alert-danger text-center">
                 <i class="fa fa-exclamation-triangle fa-lg"></i>
                 <strong>
-                  This site is an active airport.<br/>
                   Failure to comply with site regulations can result in you
                   being asked to leave the event without a refund.
                 </strong>
@@ -70,7 +65,7 @@
 
               <p>
                 Take extra precautions to ensure the site is kept safe, clean and not damaged in any way.
-                We need to build a positive relationship with the airport so we can continue use of the site.
+                We need to build a positive relationship with the sports complex so we can continue use of the site.
                 Remind others around you if they appear to have forgotten the rules. There will be a number
                 of garbage cans located near the paddock, grid, and trailer. Please use them. AZBR will provide
                 12"x12" boards for use with jacks and jack stands. They must be used to prevent damage to the
@@ -78,7 +73,23 @@
               </p>
               <ol>
                 <li>
-                  Site entry for participants is <a href="<?php echo baseHref; ?>autoross/calendar.php">listed
+                  No glass containers are permitted onsite.
+                </li>
+                <li>
+                  No animals or pets are allowed. Service animals that provide specific ADA qualifying assistance are allowed,
+                  unfortunately emotional support animals do not qualify for this.
+                </li>
+                <li>
+                  Strictly follow all posted speed limits. Forgeus Ave and other streets internal to the complex
+                  are 25MPH or lower. Once in paddock, the speed limit is 10MPH.
+                </li>
+                <li>
+                  All participants and spectators shall remain in the autocross site area (paddock and course), as this
+                  is the only part of the sports complex we have rented. If you see a closed gate anywhere, do not attempt
+                  to open it.
+                </li>
+                <li>
+                  Site entry time for participants is <a href="<?php echo baseHref; ?>autoross/calendar.php">listed
                   on the event calendar for each event</a>. If you show up before the listed time please wait
                   outside the black fence as we will be setting up the paddock and other required boundaries.
                 </li>
@@ -87,18 +98,9 @@
                   course/site map. Park on the pavement only. Do not park on the dirt.
                 </li>
                 <li>
-                  At each event, a mandatory drivers meeting will be held at the time
+                  At each event, an event meeting (mandatory for all drivers and spectators) will be held at the time
                   <a href="<?php echo baseHref;?>events/calendar.php">indicated on the event calendar</a>.
                   If more time is needed for setup/course walking we can move this out as required.
-                </li>
-                <li>
-                  The Beech Starship aircraft located on the site are off limits. Do not visit them.
-                </li>
-                <li>
-                  All participants and spectators shall remain in the autocross site area. This is
-                  defined by the lighter pavement area (uncoated) and can be seen on the overview map
-                  as the largest yellow rectangle. The aircraft taxi ways on the west and north edges are
-                  off limits. They are coated and appear darker.
                 </li>
                 <li>
                   Boards shall be used under jacks and jack stands to prevent damage to the pavement.
@@ -130,18 +132,13 @@
                   then put a muffler on. If you have to question whether your car loudness is close
                   to the limit, then put the muffler on.
                 </li>
-                <li>One (1) portable toilet will be provided (rented by AZBR). Please keep it clean.</li>
                 <li>
-                  The site is an active airport and any FOD (Foreign Object Debris), from a Kleenex to a
-                  water bottle, is extremely dangerous to the operating aircraft and to our future use
-                  of the site. Contain your own trash and pick up anything you see. There will be a few
-                  garbage cans on site. Use those or take trash off site when you leave.
+                  TODO: restrooms?
                 </li>
                 <li>
-                  If an aircraft taxis on the either of the two taxi ways immediately adjacent to the course,
-                  the event will be stopped until the aircraft is clear of the area. If you are in the middle
-                  of a run you will get a re-run. This is not a likely scenario, but be prepared in case it
-                  happens.
+                  Any loose trash left after the event is extremely dangerous to our future use
+                  of the site. Contain your own trash and pick up anything you see. There will be a few
+                  garbage cans on site. Use those or take trash off site when you leave.
                 </li>
               </ol>
             </div>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
               <h2 class="azbr-color"><em>New site - Kino Sports Complex</em></h2>
               <div class="well well-sm">
                 <div class="row">
-                  <div  class="col-md-8">
+                  <div  class="col-md-12">
                     <p>
                       AZBR is pleased to announce that our next Solo event, on Sunday October 23, will be held at a new site: Kino Sports Complex.
                       This will be held in one of the large parking lots, allowing for more traditional autocross course designs.

--- a/index.html
+++ b/index.html
@@ -9,7 +9,22 @@
 ?>
         <div class="row">
           <div class="col-md-7">
-  
+              <h2 class="azbr-color"><em>New site - Kino Sports Complex</em></h2>
+              <div class="well well-sm">
+                <div class="row">
+                  <div  class="col-md-8">
+                    <p>
+                      AZBR is pleased to announce that our next Solo event, on Sunday October 23, will be held at a new site: Kino Sports Complex.
+                      This will be held in one of the large parking lots, allowing for more traditional autocross course designs.
+                    </p>
+                    <p>
+                      As with any new site, it's critical that we obey the site-specific rules in order to maintain future access to the site.
+                      Please visit the <a href="<?php echo baseHref; ?>autocross/kino.html"> site details page</a> for more information on what to expect, 
+                      as well as the <a href="<?php echo baseHref; ?>autocross/calendar">calendar page</a> to see what the new schedule will be.
+                    </p>
+                  </div>
+                </div>
+              </div>
             <h2 class="azbr-color"><em>Tucson Autocross</em></h2>
             <div class="well well-sm">
               <?php AutoxEvents::upcoming_block( $regApiIds['AZBR'], $regApiKeys['AZBR'] ); ?>


### PR DESCRIPTION
## Why are we doing this?

Update schedule for the next three Kino events, add event page for Kino, announcement on front page, board member update

## How can someone view these changes?

dev website

Steps to manually verify the change:

1. [View the front page](https://dev.azbrscca.org/)
2. [View the autocross event calendar](https://dev.azbrscca.org/autocross/calendar.html)
3. [View the autocross "site and entry fee information" page](https://dev.azbrscca.org/autocross/details.html)
4. [View the Kino event site](https://dev.azbrscca.org/autocross/kino.html)
5. [View the board member page](https://dev.azbrscca.org/about/board.html)

## What possible risks or adverse effects are there?

Content accuracy - schedule and event info needs to be correct or people will get lost

## What are the follow-up tasks?

In December, we stop having Kino events for a while. We'll need to undo these changes for Musselman, and then redo them every time there's a Kino event (yuck); or we need to add additional intelligence to the calendar page to show site-specific schedules, and that maybe means organizing things differently.

## Are there any known issues?

_(Optional)_
