### PR TITLE
feat: 2025 entry fee increase

### DIFF
--- a/autocross/paypal.html
+++ b/autocross/paypal.html
@@ -198,34 +198,34 @@
               </p>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  &nbsp;<br/>Single Day Competition Entry Only - $30
+                  &nbsp;<br/>Single Day Competition Entry Only - $42
                 </div>
                 <div class="col-md-4 col-xs-6">
-                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
-                  <input type="hidden" name="cmd" value="_s-xclick">
-                  <input type="hidden" name="hosted_button_id" value="9JCHFM4ZXT6AG">
+                  <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+                  <input type="hidden" name="cmd" value="_s-xclick" />
+                  <input type="hidden" name="hosted_button_id" value="L9UEHWPF83EL2" />
                   <table>
-                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200" value="<?php echo $registration[ 'entrant_name_first' ], " ", $registration[ 'entrant_name_last' ]?>"></td></tr>
                   </table>
-                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                  <input type="hidden" name="currency_code" value="USD" />
+                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Add to Cart" />
                   </form>
                 </div>
               </div>
               <p/>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  &nbsp;<br/>Single Day Competition + Time Only - $40
+                  &nbsp;<br/>Single Day Competition + Time Only - $52
                 </div>
                 <div class="col-md-4 col-xs-6">
-                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
-                  <input type="hidden" name="cmd" value="_s-xclick">
-                  <input type="hidden" name="hosted_button_id" value="EASWPKGAUB6HY">
+                  <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+                  <input type="hidden" name="cmd" value="_s-xclick" />
+                  <input type="hidden" name="hosted_button_id" value="UUPMCBF3EUF6N" />
                   <table>
-                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200" value="<?php echo $registration[ 'entrant_name_first' ], " ", $registration[ 'entrant_name_last' ]?>"></td></tr>
                   </table>
-                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                  <input type="hidden" name="currency_code" value="USD" />
+                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Add to Cart" />
                   </form>
                 </div>
               </div>
@@ -242,34 +242,34 @@
               </div>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  &nbsp;<br/>Single Day Competition Entry Only - $45
+                  &nbsp;<br/>Single Day Competition Entry Only - $57
                 </div>
                 <div class="col-md-4 col-xs-6">
-                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
-                  <input type="hidden" name="cmd" value="_s-xclick">
-                  <input type="hidden" name="hosted_button_id" value="MCT4HMFYRQYNE">
+                  <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+                  <input type="hidden" name="cmd" value="_s-xclick" />
+                  <input type="hidden" name="hosted_button_id" value="KKZY7CYF6YGHA" />
                   <table>
-                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200" value="<?php echo $registration[ 'entrant_name_first' ], " ", $registration[ 'entrant_name_last' ]?>"></td></tr>
                   </table>
-                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                  <input type="hidden" name="currency_code" value="USD" />
+                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Add to Cart" />
                   </form>
                 </div>
               </div>
               <p/>
               <div class="row">
                 <div class="col-md-4 col-xs-6">
-                  &nbsp;<br/>Single Day Competition + Time Only - $55
+                  &nbsp;<br/>Single Day Competition + Time Only - $67
                 </div>
                 <div class="col-md-4 col-xs-6">
-                  <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
-                  <input type="hidden" name="cmd" value="_s-xclick">
-                  <input type="hidden" name="hosted_button_id" value="VYQZ5UML7B3ZE">
+                  <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+                  <input type="hidden" name="cmd" value="_s-xclick" />
+                  <input type="hidden" name="hosted_button_id" value="HZ88SZ9TL2E54" />
                   <table>
-                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200"></td></tr>
+                  <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200" value="<?php echo $registration[ 'entrant_name_first' ], " ", $registration[ 'entrant_name_last' ]?>"></td></tr>
                   </table>
-                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-                  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                  <input type="hidden" name="currency_code" value="USD" />
+                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Add to Cart" />
                   </form>
                 </div>
               </div>

--- a/common/Display.php
+++ b/common/Display.php
@@ -225,11 +225,11 @@
               </div>
               <div class="row">
                 <div class="col-md-8 col-xs-8">Registering Online</div>
-                <div class="col-md-4 col-xs-2"><i class="fa fa-usd"></i> 30</div>
+                <div class="col-md-4 col-xs-2"><i class="fa fa-usd"></i> 42</div>
               </div>
               <div class="row">
                 <div class="col-md-8 col-xs-8">Registering On Site</div>
-                <div class="col-md-4 col-xs-2"><i class="fa fa-usd"></i> 50</div>
+                <div class="col-md-4 col-xs-2"><i class="fa fa-usd"></i> 65</div>
               </div>
 
               <div class="row">
@@ -239,11 +239,11 @@
               </div>
               <div class="row">
                 <div class="col-md-8 col-xs-8">Registering Online</div>
-                <div class="col-md-4 col-xs-2"><i class="fa fa-usd"></i> 45</div>
+                <div class="col-md-4 col-xs-2"><i class="fa fa-usd"></i> 57</div>
               </div>
               <div class="row">
                 <div class="col-md-8 col-xs-8">Registering On Site</div>
-                <div class="col-md-4 col-xs-2"><i class="fa fa-usd"></i> 65</div>
+                <div class="col-md-4 col-xs-2"><i class="fa fa-usd"></i> 80</div>
               </div>
               <br/>
               <div class="row">


### PR DESCRIPTION
## Why are we doing this?

We raised prices for the remainder of the year. Static site needs to be updated accordingly.

I created four new paypal buttons with the correct, new entry fees. I replaced the old buttons on the paypal page and updated the display helper with 

I left the old buttons in there in case we accidentally forget to update an event's prices somehow, to minimize the chaos.

## How can someone view these changes?

dev site

Steps to manually verify the change:

1. On the top nav, go to Autocross -> Site & Entry Fee Information. Verify the amounts on the right hand side are correct
2. On this page, click the Pay with Paypal button. Try out each of the four paypal buttons and make sure the in-cart price matches the advertised price on the page.

## What possible risks or adverse effects are there?

Biggest risk is incorrect price, which will generate complaints and confusion.

## What are the follow-up tasks?

* Deploy to static site

## Are there any known issues?

None

_(Optional)_
