### PR TITLE
fix: results missing podium club category

### DIFF
--- a/js/azbr/autocross/results.js
+++ b/js/azbr/autocross/results.js
@@ -1,6 +1,6 @@
 $( document ).ready( function() {  
 
-  var categories = [ 'PAX', 'Open', 'Street Tire', 'Ladies', 'Novice', 'Time Only' ];
+  var categories = [ 'PAX', 'Open', 'Street Tire', 'Ladies', 'Novice', 'Podium Club', 'Time Only' ];
   var classes = new Array();
   var options = {};
   var eventJSON, results, seriesJSON;


### PR DESCRIPTION
## Why are we doing this?

We added a Podium Club category but the results page needed a tweak.

## How can someone view these changes?

dev site

## What possible risks or adverse effects are there?

almost none, this is the smallest change

## What are the follow-up tasks?

This stuff is hardcoded which is sub optimal. Should pull dynamically from the DB and go from there.

## Are there any known issues?
None
